### PR TITLE
Adding resize fixes, buildstream ending on scope.destroy

### DIFF
--- a/client/directives/directiveLogView.js
+++ b/client/directives/directiveLogView.js
@@ -90,7 +90,6 @@ function logView(
               writeToTerm('Unknown Build Error Occurred');
             }
           } else { // build in progress
-            console.log('Creating a build stream for build: ', buildId);
             initBuildStream();
           }
         });


### PR DESCRIPTION
Adding resize fixes
 Adding scope.onDestroy -> destroy terminal, end the buildstream
