### PR TITLE
Allowing the UI to fetch all of the github repos

### DIFF
--- a/client/directives/directiveRepoList.js
+++ b/client/directives/directiveRepoList.js
@@ -433,6 +433,7 @@ function repoList (
         function fetchVersion (callback) {
           data.version.fetch(function (err) {
             $rootScope.safeApply();
+            callback(err);
           });
           $rootScope.safeApply();
         }


### PR DESCRIPTION
This change makes the UI keep fetching the repo list as long as 100 (the max amount) come back from the server.  Once the list comes back empty, or below 100, it resumes the rest of what it was doing
