### PR TITLE
Creating env renaming service

### DIFF
--- a/client/services/serviceRegExpQuote.js
+++ b/client/services/serviceRegExpQuote.js
@@ -1,0 +1,4 @@
+require('app')
+  .factory('regexpQuote', function () {
+    return require('regexp-quote');
+  });

--- a/client/services/serviceUpdateEnvName.js
+++ b/client/services/serviceUpdateEnvName.js
@@ -1,0 +1,63 @@
+require('app')
+  .factory('updateEnvName', updateEnvName);
+/**
+ * Make copies of all of the dependent instances, then finally the given one.
+ * (working backward through the list to minimize fixing dependencies)
+ *
+ * Create instance url map
+ *
+ * For each instance.dependency
+ *  for each url in map -> replace key with object in env
+ *  keep og url
+ *  fork instance
+ *    > update instance with new name, updated envs
+ *      > store og/new url in instance url map
+ *
+ * @param instance instance that was just changed (should contain
+ * @param rootInstance root instance (which is being forked) with all of the dependent instances
+ * @returns {*}
+ */
+
+
+/**
+ * This takes in an instance with a new name on its state, and changes all of the envs that have
+ * it as a
+ * @param keypather
+ * @param regexpQuote
+ * @returns {Function}
+ */
+function updateEnvName(
+  keypather,
+  regexpQuote
+) {
+  return function (instance, rootInstance) {
+
+    function makeRegexp(instanceName) {
+      //                  Checks for the = and http(s)
+      // do it like this so the first match ($1) is always the same
+      return new RegExp('(=\\s*|=\\s*https?:\/\/)' + regexpQuote(instanceName) +
+        '(\\.[^.]*\\.runnable\\.io|runnable3\\.net)', 'gim');
+      //    Checks for a .SOMETHING. then either runnable.io or runnable3.net
+    }
+
+    if (!rootInstance || !instance || !rootInstance.dependencies ||
+        !keypather.get(instance, 'state.name')) {
+      return false;
+    }
+    var regex = makeRegexp(instance.attrs.name);
+    var newName = instance.state.name;
+    var instancesArray = [rootInstance].concat(rootInstance.dependencies.models);
+    instancesArray.forEach(function (dependency) {
+      var envs = keypather.get(dependency, 'state.env') || dependency.attrs.env;
+      if (envs) {
+        // Flatten out the array so we can regex all at once
+        var fixedEnvs = envs.join('\n').replace(regex, '$1' + newName + '$2');
+        // Add the new envs into the state object
+        keypather.set(dependency, 'state.env', fixedEnvs.split('\n').filter(function (n) {
+          return n.length;
+        }));
+      }
+    });
+    return true;
+  };
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "moment": "~2.7.0",
     "ngStorage": "git+https://github.com/cflynn07/ngStorage.git#v0.4.0",
     "primus": "^2.3.0",
+    "regexp-quote": "0.0.0",
     "runnable": "git+ssh://git@github.com:CodeNow/runnable-api-client#v0.37.2",
     "term.js": "git://github.com/Runnable/term.js.git#a6ad55713831a99b4db385f6787dae66654ac169",
     "uuid": "^2.0.1"

--- a/test/unit/services/serviceUpdateEnvName.unit.js
+++ b/test/unit/services/serviceUpdateEnvName.unit.js
@@ -1,0 +1,255 @@
+/**
+ * Things to test
+ *
+ * Root instance, no dependencies
+ * Root instance, some deps, change name (shouldn't modify anything)
+ *
+ * depInstance name the same as the username in url
+ * depInstance name same as 2 others, except minor change
+ *
+ * Have 5+ deps
+ *  change at the top
+ *  change at the bottom
+ *  change with one envs having multiple matches
+ *
+ *
+ */
+
+function testModels() {
+  return [
+    {
+      attrs: {
+        name: 'apple',
+        env: [
+          'a=morange.user.runnable.io',
+          'b =http://orange.user.runnable.io',
+          'c = orange.user.runnable.io',
+          'e = banana.user.runnable.io:2031/github/api',
+          'f= banana.manana.user.runnable.io:2031/github/api',
+          'c = user.user.runnable.io'
+        ]
+      },
+      changes: {
+        morange: [0],
+        orange: [1, 2],
+        banana: [3],
+        'banana.mana': [4],
+        user: [5]
+      }
+    }, {
+      attrs: {
+        name: 'morange',
+        env: [
+          'a= banana.manana.user.runnable.io:2031/github/api',
+          'c = orange.user.runnable.io',
+          'e = http://morange.user.runnable.io:1231'
+        ]
+      },
+      state: {
+        env: [
+          'a= banana.user.runnable.io:2031/github/api',
+          'c = user.user.runnable.io',
+          'e = http://morange.user.runnable.io:1231'
+        ]
+      },
+      changes: {
+        morange: [2],
+        banana: [0],
+        user: [1]
+      }
+    }, {
+      attrs: {
+        name: 'user',
+        env: [
+          'a= banana.manana.user.runnable.io:2031/github/api',
+          'c = orange.user.runnable.io'
+        ]
+      },
+      changes: {
+        orange: [1],
+        'banana.mana': [0]
+      }
+    }, {
+      attrs: {
+        name: 'banana.manana',
+        env: [
+          'a = banana.user.runnable.io:2031/github/api'
+        ]
+      },
+      changes: {
+        banana: [0]
+      }
+    }, {
+      attrs: {
+        name: 'banana'
+      }
+    },
+    {
+      attrs: {
+        name: 'orange'
+      }
+    }
+  ];
+}
+
+function getModelNameArray(model) {
+  return model.map(function(value) {
+    return value.attrs.name;
+  });
+}
+
+function testRoot(models) {
+  return {
+    attrs: {
+      name: 'pineapple',
+      env: [
+        'a=morange.user.runnable.io',
+        'b =http://apple.user.runnable.io',
+        'c = orange.user.runnable.io',
+        'd = https://morange.user.runnable.io:3232',
+        'e = banana.user.runnable.io:2031/github/api',
+        'f= banana.manana.user.runnable.io:2031/github/api',
+        'f= pineapple.user.runnable.io:2031/github/api',
+        'c = user.user.runnable.io'
+      ]
+    },
+    state: {
+      name: 'shmapple'
+    },
+    dependencies: {
+      models: models || testModels()
+    },
+    changes: {
+      morange: [0, 3],
+      orange: [2],
+      banana: [4],
+      pineapple: [6],
+      apple: [1],
+      'banana.mana': [5],
+      user: [7]
+    }
+  };
+}
+
+describe('serviceUpdateEnvName'.bold.underline.blue, function () {
+  var updateEnvName, keypather;
+  beforeEach(function () {
+    angular.mock.module('app', function ($provide) {});
+    angular.mock.inject(function (_updateEnvName_, _keypather_) {
+      updateEnvName = _updateEnvName_;
+      keypather = _keypather_;
+    });
+  });
+  describe('basic operations'.blue, function () {
+    describe('testing invalid input', function () {
+      [
+        ['empty everything', null, null],
+        ['empty instance', null, testRoot()],
+        ['empty rootInstance', testModels()[0], null],
+        ['empty dependencies', testModels()[0], testModels()[1]],
+        ['no name change', testModels()[1], testRoot()]
+      ].forEach(function (testArray) {
+          it('should handle ' + testArray[0], function () {
+            var result = updateEnvName(testArray[1], testArray[2]);
+            expect(result).to.be.false;
+          });
+        });
+    });
+  });
+  describe('editing a single entry', function () {
+    it('renaming apple should only affect root', function () {
+      var instance = testModels()[0];
+      var root = testRoot();
+      keypather.set(instance, 'state.name', 'chicken');
+      var result = updateEnvName(instance, root);
+      expect(result).to.be.true;
+      expect(root.state).to.exist;
+      expect(root.state.env).to.exist;
+      expect(root.state.env.length).to.eql(root.attrs.env.length);
+      compareArrays(root.state.env, root.attrs.env, [1]);
+      expect(root.state.env[1]).to.eql('b =http://chicken.user.runnable.io');
+
+    });
+    it('renaming root should only affect itself', function () {
+      var root = testRoot();
+      keypather.set(root, 'state.name', 'chicken');
+      var result = updateEnvName(root, root);
+      expect(result).to.be.true;
+      expect(root.state).to.exist;
+      expect(root.state.env).to.exist;
+      expect(root.state.env.length).to.eql(root.attrs.env.length);
+      compareArrays(root.state.env, root.attrs.env, [6]);
+      expect(root.state.env[6]).to.eql('f= chicken.user.runnable.io:2031/github/api');
+
+    });
+    it('renaming morange should update itself', function () {
+      var originalInstance = testModels()[1];
+      // This instance already has an state change
+      expect(originalInstance.state.env).to.exist;
+      var root = testRoot();
+      keypather.set(originalInstance, 'state.name', 'chicken');
+      var result = updateEnvName(originalInstance, root);
+      expect(result).to.be.true;
+      var changedInstance = root.dependencies.models[1];
+      expect(changedInstance.state).to.exist;
+      expect(changedInstance.state.env).to.exist;
+      // NOTE: comparing originalInstance, since it is the unchanged version
+      expect(changedInstance.state.env.length).to.eql(originalInstance.state.env.length);
+      compareArrays(changedInstance.state.env, originalInstance.state.env, [2]);
+      expect(changedInstance.state.env[2]).to.eql('e = http://chicken.user.runnable.io:1231');
+    });
+  });
+  describe('advanced editing', function () {
+    it('renaming banana should change a lot', function () {
+      var INSTANCE_NAME = 'banana';
+      var INSTANCE_INDEX = 4;
+
+      var originalDependencies = testModels();
+      var instance = originalDependencies[INSTANCE_INDEX];
+      expect(instance.attrs.name).to.eql(INSTANCE_NAME);
+      var root = testRoot();
+      keypather.set(instance, 'state.name', 'chicken');
+      var result = updateEnvName(instance, root);
+      expect(result).to.be.true;
+      originalDependencies.forEach(function (ogDeps, index) {
+        var ogEnvs = keypather.get(ogDeps, 'state.env') || ogDeps.attrs.env;
+        var changedInstance = root.dependencies.models[index];
+        var expectedChanges = keypather.get(changedInstance, 'changes.' + INSTANCE_NAME);
+        if (expectedChanges) {
+          compareArrays(changedInstance.state.env, ogEnvs, expectedChanges);
+          expect(keypather.get(changedInstance, 'state.env.length')).to.eql(ogEnvs.length);
+        }
+      });
+    });
+    it('should work with renaming everything', function () {
+      var originalDependencies = testModels();
+      getModelNameArray(originalDependencies).forEach(function (INSTANCE_NAME, INSTANCE_INDEX) {
+        var instance = originalDependencies[INSTANCE_INDEX];
+        expect(instance.attrs.name).to.eql(INSTANCE_NAME);
+        var root = testRoot();
+        keypather.set(instance, 'state.name', 'chicken');
+        var result = updateEnvName(instance, root);
+        expect(result).to.be.true;
+        originalDependencies.forEach(function (ogDeps, index) {
+          var ogEnvs = keypather.get(ogDeps, 'state.env') || ogDeps.attrs.env;
+          var changedInstance = root.dependencies.models[index];
+          var expectedChanges = keypather.get(changedInstance, 'changes.' + INSTANCE_NAME);
+          if (expectedChanges) {
+            compareArrays(changedInstance.state.env, ogEnvs, expectedChanges);
+            expect(keypather.get(changedInstance, 'state.env.length')).to.eql(ogEnvs.length);
+          }
+        });
+      });
+    });
+  });
+});
+
+function compareArrays(array1, array2, notThese) {
+  array1.forEach(function (item, index) {
+    if (notThese.indexOf(index) < 0) {
+      expect(item).to.eql(array2[index]);
+    } else {
+      expect(item).to.not.eql(array2[index]);
+    }
+  });
+}


### PR DESCRIPTION
Created service to quickly modify all envs matching an instance changing it's name.
Providing unit tests with 100% coverage
Adding regexQuote for use with regexes
