### PR TITLE
Experiment scrolling improvement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runnable-angular",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "description": "rewrite of runnable-web in angularjs",
   "scripts": {


### PR DESCRIPTION
currently in testing on http://casey_web.codenow.runnable.io/

With our current scroll sensitivity it's almost impossible to scroll less than 50 lines at a time. Locating a specific set of lines via scrolling is very difficult.

With these changes it's now possible to scroll 1, 2 or 3 lines at a time but I've also tried to preserve a higher speed rate of scrolling when trying to traverse large portions of a long log/terminal output for efficiency

to test this you can find some long logs or just type this into a terminal:

`for i in {1..1000}; do echo $i; done;`
