### PR TITLE
Fixing env modal (for now) Now setting dependency opts.name when build is clicked Fixing tests removing console.log

### DIFF
--- a/client/directives/envVars/directiveEnvVars.js
+++ b/client/directives/envVars/directiveEnvVars.js
@@ -11,6 +11,7 @@ function envVars(
   $rootScope
 ) {
   return {
+    replace: true,
     restrict: 'A',
     templateUrl: 'viewEnvVars',
     scope: {

--- a/client/directives/modals/modalGettingStarted/directiveGettingStarted.js
+++ b/client/directives/modals/modalGettingStarted/directiveGettingStarted.js
@@ -53,12 +53,10 @@ function modalGettingStarted(
       $scope.actions = {
         addDependency: function (instance, fromExisting) {
           var envs = keypather.get(instance, 'containers.models[0].urls()') || [];
-          var newName = getNewForkName(instance, $scope.data.instances, true);
           var envName = instance.attrs.name.replace(/-/gm, '_').toUpperCase();
           $scope.state.dependencies.push({
             instance: instance,
             opts: !fromExisting ? {
-              name: newName,
               env: instance.attrs.env
             } : null,
             reqEnv: envs.map(function (url, index) {
@@ -66,7 +64,7 @@ function modalGettingStarted(
               return {
                 name: thisEnvName,
                 placeholder: thisEnvName,
-                url: !fromExisting ? url.replace(instance.attrs.name, newName) : url
+                url: url
               };
             })
           });
@@ -107,9 +105,9 @@ function modalGettingStarted(
           var unwatchDf = $scope.$watch('state.dockerfile', function (n) {
             if (!n) { return; }
             unwatchDf();
-            $scope.state.opts.env = generateEnvs($scope.state.dependencies);
-
             var unwatchInstances = $scope.$watch('data.instances', function (n) {
+              generateDependencyNames();
+              $scope.state.opts.env = generateEnvs($scope.state.dependencies);
               if (!n) { return; }
               unwatchInstances();
               $scope.state.opts.name =
@@ -240,6 +238,18 @@ function modalGettingStarted(
             if (counter) {
               counter.next(err);
             }
+          }
+        });
+      }
+
+      function generateDependencyNames() {
+        $scope.state.dependencies.forEach(function (item) {
+          if (item.opts) {
+            var newName = getNewForkName(item.instance, $scope.data.instances, true);
+            item.opts.name = newName;
+            item.reqEnv.forEach(function (env) {
+              env.url = env.url.replace(item.instance.attrs.name, newName);
+            });
           }
         });
       }

--- a/client/services/serviceFetchStackInfo.js
+++ b/client/services/serviceFetchStackInfo.js
@@ -8,7 +8,6 @@ function fetchStackInfo(
 ) {
   return function (cb) {
     function callback(err, res, body) {
-      console.log(err, res, body);
       var stacks = [];
       Object.keys(body).forEach(function (key) {
         var stack = body[key];

--- a/test/unit/directives/modals/modalGettingStarted/directiveModalGettingStarted.unit.js
+++ b/test/unit/directives/modals/modalGettingStarted/directiveModalGettingStarted.unit.js
@@ -253,7 +253,6 @@ describe('directiveModalGettingStarted'.bold.underline.blue, function () {
       it('should fork a new one', function () {
         $elScope.actions.addDependency(instance);
 
-        sinon.assert.calledWith(ctx.getNewForkNameMock, instance);
         expect($elScope.state.dependencies[0]).to.be.ok;
         expect($elScope.state.dependencies[0].instance).to.equal(instance);
         expect($elScope.state.dependencies[0].opts).to.be.ok;
@@ -264,7 +263,7 @@ describe('directiveModalGettingStarted'.bold.underline.blue, function () {
           .to.equal(instance.attrs.name.toUpperCase() + '_HOST');
         expect($elScope.state.dependencies[0].reqEnv[0].placeholder).to.be.ok;
         // Should have new name
-        expect($elScope.state.dependencies[0].reqEnv[0].url).to.equal(instance.attrs.name + '0');
+        expect($elScope.state.dependencies[0].reqEnv[0].url).to.equal(instance.attrs.name);
         expect($elScope.state.dependencies[0].reqEnv[1].name)
           .to.equal(instance.attrs.name.toUpperCase() + '_HOST1');
         expect($elScope.state.dependencies[0].reqEnv[1].url).to.equal('asdasd.asdasd.asdas');
@@ -272,7 +271,6 @@ describe('directiveModalGettingStarted'.bold.underline.blue, function () {
       it('should use an existing', function () {
         $elScope.actions.addDependency(instance, true);
 
-        sinon.assert.calledWith(ctx.getNewForkNameMock, instance);
         expect($elScope.state.dependencies[0]).to.be.ok;
         expect($elScope.state.dependencies[0].instance).to.equal(instance);
         expect($elScope.state.dependencies[0].opts).to.not.be.ok;
@@ -525,6 +523,10 @@ describe('directiveModalGettingStarted'.bold.underline.blue, function () {
       $elScope.actions.addDependency(ctx.instanceLists[2]);
 
       $scope.defaultActions.close = sinon.spy(function () {
+        expect($elScope.state.dependencies[0].opts.name)
+            .to.equal($elScope.state.dependencies[0].instance.attrs.name + 0);
+        expect($elScope.state.dependencies[2].opts.name)
+            .to.equal($elScope.state.dependencies[2].instance.attrs.name + 1);
         sinon.assert.called(ctx.instanceLists[0].copy);
         sinon.assert.notCalled(ctx.instanceLists[1].copy);
         sinon.assert.called(ctx.instanceLists[2].copy);
@@ -552,7 +554,7 @@ describe('directiveModalGettingStarted'.bold.underline.blue, function () {
       expect($elScope.state.dockerfile).to.be.ok;
 
       expect($elScope.state.opts.env).to.be.ok;
-      expect($elScope.state.opts.name).to.equal(ctx.repo1.attrs.name + (ctx.newForkNameCount - 1));
+      expect($elScope.state.opts.name).to.equal(ctx.repo1.attrs.name + 2);
 
       sinon.assert.called(ctx.getNewForkNameMock);
     });


### PR DESCRIPTION
Fixing env modal (for now)
Now setting dependency opts.name when build is clicked
Fixing tests
removing console.log
