### PR TITLE
Disable integrations dialog for few days

### DIFF
--- a/client/directives/popovers/popoverAccountMenu/viewPopoverAccountMenu.jade
+++ b/client/directives/popovers/popoverAccountMenu/viewPopoverAccountMenu.jade
@@ -33,16 +33,16 @@
     ul.list.popover-list(
       ng-if = "data.isMainPage"
     )
-      li.list-item.popover-list-item(
-        modal
-        modal-actions = "actions.actionsModalIntegrations"
-        modal-data = "data.dataModalIntegrations"
-        modal-template = "viewOpenModalIntegrations"
-      )
-      //-   | Integrations
       //- li.list-item.popover-list-item(
-      //-   ng-if = "data.inDev"
-      //-   ng-click = "actions.clearAllUserOptions();"
+      //-   modal
+      //-   modal-actions = "actions.actionsModalIntegrations"
+      //-   modal-data = "data.dataModalIntegrations"
+      //-   modal-template = "viewOpenModalIntegrations"
+      //- )
+      //-   | Integrations
+      li.list-item.popover-list-item(
+        ng-if = "data.inDev"
+        ng-click = "actions.clearAllUserOptions();"
       ) Reset Coachmarks
       li.list-item.popover-list-item
         a.list-link(


### PR DESCRIPTION
We need to temporary disable integrations dialog. The reason is because we are removing slack/hipchat notifications to the public rooms.
We will have just private messaging. But it's not ready yet. Should be implemented some days after.

Related to the backend PR https://github.com/CodeNow/api/pull/569 - which removes public messaging.
