### PR TITLE
Correct commit times on repository popover

### DIFF
--- a/client/directives/editRepoCommit/viewEditRepoCommit.jade
+++ b/client/directives/editRepoCommit/viewEditRepoCommit.jade
@@ -21,7 +21,7 @@
         xlink:href = "#icons-commit"
       )
     | {{ activeCommit.attrs.commit.message | limitTo:30 }}
-    small.small.repository-detail {{ activeCommit.attrs.commit.author.date | timeAgo }}
+    small.small.repository-detail {{ activeCommit.attrs.commit.author.date | timeFrom }}
   svg.iconnables.icons-arrow-down
     use(
       xlink:href = "#icons-arrow-down"

--- a/client/directives/editRepoCommit/viewPopoverRepositoryToggle.jade
+++ b/client/directives/editRepoCommit/viewPopoverRepositoryToggle.jade
@@ -54,7 +54,7 @@
       )
         .toggle-group-title {{ ::commit.attrs.commit.message | limitToEllipsis:72 }}
         .toggle-group-detail.clearfix
-          small.small {{ ::commit.attrs.author.login }}—{{ ::commit.attrs.commit.author.date | timeAgo }}
+          small.small {{ ::commit.attrs.author.login }}—{{ commit.attrs.commit.author.date | timeFrom }}
           a.small.link-text(
             ng-href = "{{ commit.attrs.html_url }}"
             ng-click = "$event.stopPropagation()"

--- a/client/directives/modals/modalGettingStarted/step1/viewModalRepoSelector.jade
+++ b/client/directives/modals/modalGettingStarted/step1/viewModalRepoSelector.jade
@@ -20,7 +20,7 @@ ul.list.list-divided
       orderBy: '-attrs.updated_at' "
   )
     span.list-item-title.text-overflow {{ repo.attrs.full_name }}
-    small.small {{ repo.attrs.updated_at | timeAgo }}
+    small.small {{ repo.attrs.updated_at | timeFrom }}
     .spinner-wrapper.spinner-sm.spinner-purple.in(
       ng-if = "repo.spin"
       ng-include = "'spinner'"

--- a/client/filters/filterTimeFrom.js
+++ b/client/filters/filterTimeFrom.js
@@ -1,0 +1,14 @@
+'use strict';
+
+// TODO include moment via service TJ made
+var moment = require('moment');
+require('app')
+  .filter('timeFrom', timeFrom);
+
+// Note: that this will return times in the future.
+// Use the "timeAgo" if you want to enforce past times.
+function timeFrom() {
+  return function (date) {
+  	return (!date) ? undefined : moment(date).fromNow();
+  };
+}


### PR DESCRIPTION
- Added commit times in the popover to the digest cycle
- Created a faster `timeFrom` filter that does not check for future dates like `timeAgo`
- Replaced instance of `timeAgo` to `timeFrom` for all git commit times
