### PR TITLE
Added error handling when we can't begin setting up the instance

### DIFF
--- a/client/directives/modals/modalGettingStarted/directiveGettingStarted.js
+++ b/client/directives/modals/modalGettingStarted/directiveGettingStarted.js
@@ -258,7 +258,7 @@ function modalGettingStarted(
           $scope.data.instances = instances;
         }).catch(function(){
           $scope.defaultActions.cancel();
-          errs.handler(new Error("We are unable to create servers at this time, please try again later."));
+          errs.handler(new Error('We are unable to create servers at this time, please try again later.'));
         });
       }
 


### PR DESCRIPTION
When we can't setup an instance's dockerfile we will close the create modal and will notify the user that we cannot create servers right now.

TODO: This MUST email us, we must get notified that this is happening as it's a mission critical thing that it isnt possible. This will probably be in rollbar once we get that in the project.
