### PR TITLE
SAN 1095 set content type

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -29,7 +29,7 @@ var views = require('./build/views/viewBundle');
  */
 app.config(function ($httpProvider) {
   $httpProvider.defaults.withCredentials = true;
-  $httpProvider.defaults.defaults.headers.delete = { 'Content-Type' : 'application/json' };
+  $httpProvider.defaults.headers.delete = { 'Content-Type' : 'application/json' };
 });
 
 /**


### PR DESCRIPTION
This fixes: https://runnable.atlassian.net/browse/SAN-1095.

The problem was with default `Content-Type` headers Angular was setting (not setting) for DELETE request.

This PR changes global default for all DELETE request. So please do think if it might break something else. I reviewed our backends routes and it seem that everything should be fine, but it would be good if someone can double check.
