### PR TITLE
consistent small state in modal forms

### DIFF
--- a/client/assets/styles/scss/modals/modals-forms.scss
+++ b/client/assets/styles/scss/modals/modals-forms.scss
@@ -18,6 +18,11 @@
         margin-top: 15px;
       }
     }
+
+    // for rows (full-width) with only small text
+    > .small:only-child {
+      margin: 6px;
+    }
   }
 
   // input column (right)

--- a/client/directives/environment/modals/forms/formFiles/viewFormFiles.jade
+++ b/client/directives/environment/modals/forms/formFiles/viewFormFiles.jade
@@ -34,4 +34,6 @@
 .table.table-drag-drop.clearfix(
   ng-include = "'viewFormFilesTable'"
 )
-small.small Copy files to the file system of this container (e.g. seed data for a database, or other files that your application expects to have available).
+
+.label
+  small.small Copy files to the file system of this container (e.g. seed data for a database, or other files that your application expects to have available).

--- a/client/directives/environment/modals/forms/formTranslation/translationIgnored/ignoredTranslationView.jade
+++ b/client/directives/environment/modals/forms/formTranslation/translationIgnored/ignoredTranslationView.jade
@@ -1,8 +1,9 @@
-.clearfix
+label.clearfix
   .label-col Ignored Files
 
 pre.ace-container.ace-runnable-dark.ace-ignored-files(
   ng-model = "ignoredFilesList"
   ui-ace = "{ useWrapMode: false, onLoad: aceLoaded, onBlur: aceBlurred }"
 )
-small.small Add the names of files you want to ignore, separated by linebreaks. We don't support regex, wildcard matches (*), or folder names.
+.label
+  small.small Add the names of files you want to ignore, separated by linebreaks. We don't support regex, wildcard matches (*), or folder names.

--- a/client/directives/environment/modals/forms/formTranslation/translationRules/translationRulesTableForm.jade
+++ b/client/directives/environment/modals/forms/formTranslation/translationRules/translationRulesTableForm.jade
@@ -19,4 +19,5 @@
   rule-table
 )
 
-small.small Find and Replace dynamically translates strings or filenames in your code. You can modify connection strings or server names in your code so containers in your sandbox can communicate with each other, or rename files when they're copied to your container without modifying your source code.
+.label
+  small.small Find and Replace dynamically translates strings or filenames in your code. You can modify connection strings or server names in your code so containers in your sandbox can communicate with each other, or rename files when they're copied to your container without modifying your source code.


### PR DESCRIPTION
Small text in container files and FnR were not styled the same as the small text in the other modal forms.
