### PR TITLE
mocked out subdirectives in editServerModalDirective tests

### DIFF
--- a/test/unit/environment/editServerModalDirective.unit.js
+++ b/test/unit/environment/editServerModalDirective.unit.js
@@ -1,4 +1,5 @@
 'use strict';
+
 describe('editServerModalDirective'.bold.underline.blue, function () {
   var ctx;
   var $timeout;
@@ -46,6 +47,37 @@ describe('editServerModalDirective'.bold.underline.blue, function () {
       $provide.value('eventTracking', ctx.eventTracking);
       $provide.value('configAPIHost', '');
       $provide.value('uploadFile', sinon.spy());
+
+      $provide.factory('serverStatusCardHeaderDirective', function () {
+        return {
+          priority: 100000,
+          terminal: true,
+          link: angular.noop
+        };
+      });
+      $provide.factory('stackSelectorFormDirective', function () {
+        return {
+          priority: 100000,
+          terminal: true,
+          link: angular.noop
+        };
+      });
+      $provide.factory('repositoryFormDirective', function () {
+        return {
+          priority: 100000,
+          terminal: true,
+          link: angular.noop
+        };
+      });
+      $provide.factory('translationRulesDirective', function () {
+        return {
+          priority: 100000,
+          terminal: true,
+          link: angular.noop
+        };
+      });
+
+
       $provide.factory('fetchDockerfileFromSource', ctx.fetchDockerfileFromSourceMock.fetch());
       $provide.factory('populateDockerfile', ctx.populateDockerfile.fetch());
       $provide.factory('loadingPromises', function ($q) {

--- a/test/unit/filters/filterOUtTemplateInstances.unit.js
+++ b/test/unit/filters/filterOUtTemplateInstances.unit.js
@@ -33,7 +33,6 @@ describe('removeTemplateInstances', function () {
       }
     ];
     var filtered = removeTemplateInstances(instances);
-    console.log(filtered);
     expect(filtered.length).to.equal(1);
     expect(filtered[0].attrs.name).to.equal('MyTEMPLATE-foo');
   });


### PR DESCRIPTION
Ran tests ~30 times with:

``` javascript
'use strict';

var exec = require('child_process').exec;

var exit = 0;
var i = 0;

function run (cb) {
  i++;
  console.log('RUNNING TESTS', i);
  exec('grunt test:unit-coverage', cb);
}

function callback (err) {
  console.log('tests done', arguments);
  if (err && err.code) {
    console.log('done');
    process.exit();
  } else {
    run(callback);
  }
}

run(callback);
```
