### PR TITLE
SAN-19-12 Help cards dissapear

### DIFF
--- a/client/services/serviceHelpCards.js
+++ b/client/services/serviceHelpCards.js
@@ -206,11 +206,13 @@ function helpCardsFactory(
     },
     clearAllCards: function () {
       this.cards.triggered = [];
+      currentCardHash = {};
       activeCard = null;
     },
     hideActiveCard: function () {
       if (this.getActiveCard()) {
         var helpCard = this.getActiveCard();
+        currentCardHash[helpCard.hash] = null;
         this.setActiveCard(null);
         var index = this.cards.triggered.indexOf(helpCard);
         this.cards.triggered.splice(index, 1);
@@ -285,6 +287,7 @@ function helpCardsFactory(
             helpCard.removed = true;
             var index = self.cards.triggered.indexOf(helpCard);
             self.cards.triggered.splice(index, 1);
+            currentCardHash[helpCard.hash] = null;
           });
           helpCard.on('refresh', function () {
             if (!helpCard.removed) {


### PR DESCRIPTION
Fixed bug where help cards wouldn't clear themselves from the current CardHash and wouldn't be able to be re-added if re-triggered.
