### PR TITLE
Newrelic quick fix

### DIFF
--- a/client/services/serviceGetInstanceClasses.js
+++ b/client/services/serviceGetInstanceClasses.js
@@ -14,7 +14,7 @@ function getInstanceClasses(
       return {}; //async loading handling
     }
     var h = {};
-    h.active = (instance.attrs.name === $state.params.instanceName);
+    h.active = (keypather.get(instance, 'attrs.name') === $state.params.instanceName);
 
     var status = keypather.get(instance, 'status()');
     var statusMap = {


### PR DESCRIPTION
Bypasses a bug with fetching instance classes when the instance isnt filled in properly.

Fixes:
https://rpm.newrelic.com/accounts/384085/browser/5920401/js_errors#id=843711841&tab_index=1
