### PR TITLE
Initializing packages for the setup server modal directive.

### DIFF
--- a/client/directives/environment/modals/modalSetupServer/setupServerModalDirective.js
+++ b/client/directives/environment/modals/modalSetupServer/setupServerModalDirective.js
@@ -34,7 +34,8 @@ function setupServerModal(
       $scope.state = {
         opts: {
           masterPod: true
-        }
+        },
+        packages: new cardInfoTypes.Packages()
       };
 
       fetchOwnerRepos($rootScope.dataApp.data.activeAccount.oauthName())

--- a/client/directives/modals/modalIntegrations/directiveIntegrations.js
+++ b/client/directives/modals/modalIntegrations/directiveIntegrations.js
@@ -4,7 +4,6 @@ require('app')
   .directive('modalIntegrations', integrations);
 
 function integrations(
-  $rootScope,
   keypather,
   fetchSettings,
   verifyChatIntegration,


### PR DESCRIPTION
To test the fix:
1. Create a NEW container from repo
2. Add a package
3. Build.
4. Notice the build no longer fails with `[object Object]` in the dockerfile
