### PR TITLE
Fixes CB is not a function.

### DIFF
--- a/client/services/serviceUser.js
+++ b/client/services/serviceUser.js
@@ -54,7 +54,7 @@ methods.forEach(function (method) {
     var opts = args.opts;
     opts = angular.extend({}, opts, this.defaultOpts);
     var cb = args.cb;
-    if (cb && typeof cb !== 'function') {
+    if (typeof cb !== 'function') {
       this.reportError('Callback defined but not a function. \nType: ' + typeof cb + ' \nJSON: '  + JSON.stringify(cb, false, 2), {
         emitter: 'Manual',
         source: 'client/services/serviceUser.js'


### PR DESCRIPTION
This fixes a bug where callback was getting called when it isn't a function. I don't yet know _how_ this happened, but we are going to add some better logging and prevent the original error from happening.

https://rollbar.com/Runnable-2/angular-web/items/52/
