### PR TITLE
Redirect to instance.home on instance destroy

### DIFF
--- a/client/controllers/instance/controllerInstance.js
+++ b/client/controllers/instance/controllerInstance.js
@@ -7,13 +7,11 @@ require('app')
  */
 function ControllerInstance(
   $localStorage,
-  $location,
   $q,
   $scope,
   $state,
   $stateParams,
   $timeout,
-  $window,
   OpenItems,
   errs,
   eventTracking,
@@ -24,8 +22,6 @@ function ControllerInstance(
   keypather,
   fetchUser,
   pageName,
-  promisify,
-  watchOncePromise,
   setLastInstance,
   loading
 ) {
@@ -71,6 +67,15 @@ function ControllerInstance(
         data.instance = instance;
         pageName.setTitle(instance.attrs.name);
         data.instance.state = {};
+
+        var goHomeOnDestroyHandler = function () {
+          $state.go('instance.home', { userName:  $state.params.userName });
+        };
+        instance.on('destroyed', goHomeOnDestroyHandler);
+        $scope.$on('$destroy', function () {
+          instance.off('destroyed', goHomeOnDestroyHandler);
+        });
+
 
         data.hasToken = keypather.get(results, 'settings.attrs.notifications.slack.apiToken');
         setLastInstance($stateParams.instanceName);


### PR DESCRIPTION
Steps to reproduce:

Open two windows.

window 1: 
1. Go to the instance detail view

window 2:
1. Go to the configure page
2. Delete the instance

Notice window 1 redirected to the first instance in the list.
