### PR TITLE
Harden UI to skip invalid configurations on the backend.

### DIFF
--- a/client/directives/dnsManager/directiveDnsManager.js
+++ b/client/directives/dnsManager/directiveDnsManager.js
@@ -11,7 +11,8 @@ function dnsManager(
   $localStorage,
   promisify,
   getInstanceMaster,
-  $q
+  $q,
+  keypather
 ) {
   return {
     restrict: 'A',
@@ -50,7 +51,7 @@ function dnsManager(
         })
         .then(function (masters) {
           $scope.directlyRelatedMasterInstances = masters.filter(function (instance) {
-            return instance.contextVersion.getMainAppCodeVersion();
+            return keypather.get(instance, 'contextVersion.getMainAppCodeVersion()');
           });
         })
         .catch(errs.handler)


### PR DESCRIPTION
Hardened UI to handle some bugs where instance might be null, or context version might not exist.
