### PR TITLE
Fix container sidebar max-height

### DIFF
--- a/client/assets/styles/scss/server/server-sidebar.scss
+++ b/client/assets/styles/scss/server/server-sidebar.scss
@@ -52,7 +52,7 @@
 .sidebar-section {
   border-bottom: 1px solid $gray-lighter;
   flex-direction: column;
-  max-height: 100%;
+  max-height: 999999px;
   overflow: hidden;
   padding: 0 12px;
   transition: max-height .15s ease-in-out;


### PR DESCRIPTION
We were using `max-height: 100%` for sections in the container sidebar, but the File Explorer section should be able to grow bigger than that. We still need to give it a numeric value so we can use css transitions.
