### PR TITLE
SAN-2388 - Redeploy on env vars with failed build.

### DIFF
--- a/client/directives/environment/modals/modalEditServer/editServerModalDirective.js
+++ b/client/directives/environment/modals/modalEditServer/editServerModalDirective.js
@@ -293,7 +293,7 @@ function editServerModal(
           })
           .then(function (promiseArrayLength) {
             // Since the initial deepCopy should be in here, we only care about > 1
-            toRebuild = promiseArrayLength > 1 || $scope.openItems.getAllFileModels(true).length;
+            toRebuild = promiseArrayLength > 1 || $scope.openItems.getAllFileModels(true).length || keypather.get($scope, 'instance.attrs.build.failed');
             toRedeploy = !toRebuild &&
               keypather.get($scope, 'instance.attrs.env') !== keypather.get($scope, 'state.opts.env');
             if (!$scope.openItems.isClean()) {


### PR DESCRIPTION
Updated so we will always re-build if the instance has a build failure last time. We can't re-deploy a failed build.

To test:
1. Create a recurring failed build
2. Change env vars
3. Hit save.
