### PR TITLE
SAN-2405 - Changing Slack Token Broken

### DIFF
--- a/client/directives/modals/modalIntegrations/directiveIntegrations.js
+++ b/client/directives/modals/modalIntegrations/directiveIntegrations.js
@@ -35,7 +35,7 @@ function integrations(
             data.slackMembers = {};
             data.ghMembers = {};
             throw err;
-          })
+          });
       }
 
       fetchSettings()


### PR DESCRIPTION
Handle failure to verify chat integration setting to false instead of doing nothing.

To test:
1. Have an org
2. Setup a valid slack integration
3. Change slack token to an invalid token
4. Verify that an error pops up when you click verify.
