### PR TITLE
fix table row pointer events

### DIFF
--- a/client/assets/styles/scss/modals/modals-edit.scss
+++ b/client/assets/styles/scss/modals/modals-edit.scss
@@ -35,7 +35,8 @@
     .btn:not(.btn-cancel),
     .input,
     .label,
-    .textarea {
+    .textarea,
+    .tr-action {
       @extend %no-touching;
       opacity: .6 !important;
     }


### PR DESCRIPTION
table rows for find and replace rules could still be hovered when the edit modal was disabled
