### PR TITLE
fix config pointer events

### DIFF
--- a/client/assets/styles/scss/deprecated/isolation-ui.scss
+++ b/client/assets/styles/scss/deprecated/isolation-ui.scss
@@ -166,7 +166,6 @@
     .btn-configure {
       height: 100%;
       margin-right: 6px;
-      pointer-events: auto;
       width: 33px;
     }
 


### PR DESCRIPTION
Pointer events weren't working on the config button in the deprecated container list. The styles for it were in `.containers.deprecated`, which didn't actually exist anywhere. I moved the styles into `.list-containers.deprecated`.
