### PR TITLE
SAN-2712 Build Dropdown Fixes

### DIFF
--- a/client/directives/environment/environmentBody/serverCards/popoverServerOptions/serverOptionsCardPopover.jade
+++ b/client/directives/environment/environmentBody/serverCards/popoverServerOptions/serverOptionsCardPopover.jade
@@ -29,7 +29,7 @@
           use(
             xlink:href = "#icons-log"
           )
-        | View {{ (['building', 'buildFailed', 'neverStarted'].indexOf(data.instance.status()) === -1) ? 'CMD' : 'Build' }} Logs
+        | View {{ (['building', 'buildFailed', 'neverStarted'].indexOf(data.status()) === -1) ? 'CMD' : 'Build' }} Logs
       li.divider
       li.list-item.popover-list-item(
         modal
@@ -43,7 +43,7 @@
         | Rename Container
       //- trigger delete confirm modal
       li.list-item.popover-list-item(
-        ng-click = "actions.deleteServer(data)"
+        ng-click = "actions.deleteServer()"
       )
         svg.iconnables
           use(

--- a/client/directives/environment/environmentBody/serverStatusCardHeaderView.jade
+++ b/client/directives/environment/environmentBody/serverStatusCardHeaderView.jade
@@ -8,6 +8,7 @@ div(
   pop-over
   pop-over-actions = "popoverServerActions"
   pop-over-options = "{\"right\":0,\"top\":47}"
+  pop-over-data = "instance"
   pop-over-template = "serverOptionsCardPopover"
 )
   //- ************

--- a/client/directives/environment/environmentBody/serverStatusCardHeaderViewCardStatus.jade
+++ b/client/directives/environment/environmentBody/serverStatusCardHeaderViewCardStatus.jade
@@ -1,5 +1,6 @@
 .container-title-wrapper.server-status-card-pop-over(
   pop-over
+  pop-over-data = "instance"
   pop-over-actions = "popoverServerActions"
   pop-over-options = "{\"centered\":true,\"top\":36}"
   pop-over-template = "serverOptionsCardPopover"


### PR DESCRIPTION
Fixed bug where data wasn't defined on the serverOptionsCardPopover making it always default to "View CMD Logs" instead of "View Build Logs" when it's building.
