### PR TITLE
Add `server` Gruntfile command for serving up app without npm install

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -506,6 +506,19 @@ module.exports = function(grunt) {
     'compress:build',
     'concurrent'
   ]);
+  grunt.registerTask('server', [
+    'copy',
+    'sass:dev',
+    'autoprefixer',
+    'jade2js',
+    'jshint:dev',
+    'autoBundleDependencies',
+    'generateConfigs',
+    'browserify:watch',
+    'jade:compile',
+    'compress:build',
+    'concurrent'
+  ]);
   grunt.registerTask('deploy', [
     'copy',
     'sass:dev',


### PR DESCRIPTION
I've run into a couple of situations where I want to debug my npm modules, but when I make a JS error the process gets restarted and I loose all my changes. This fixes this problem by introducing a `grunt server` command that does the same thing as `grunt`, but without installing npm modules.
