### PR TITLE
SAN-2726-cant-rename-file-in-dockerfile-tool

### DIFF
--- a/client/controllers/filePopoverController.js
+++ b/client/controllers/filePopoverController.js
@@ -36,6 +36,10 @@ function FilePopoverController(
         .catch(errs.handler);
       $rootScope.$broadcast('close-popovers');
     },
+    rename: function (fileOrDir, newValue) {
+      return loadingPromises.add(self.loadingPromisesTarget, promisify(fileOrDir, 'rename')(newValue))
+        .catch(errs.handler);
+    },
     renameFolder: function () {
       $scope.editFolderName = true;
       $scope.actions.focusInputElement();

--- a/client/directives/components/explorer/fileTreeDirDirective.js
+++ b/client/directives/components/explorer/fileTreeDirDirective.js
@@ -69,7 +69,7 @@ function fileTreeDir(
         if (newValue === $scope.dir.attrs.name) {
           return;
         }
-        $scope.dir.rename(newValue, errs.handler);
+        return $scope.FPC.actions.rename($scope.dir, newValue);
       };
 
       actions.handleClickOnFolderInput = function (event) {
@@ -101,7 +101,7 @@ function fileTreeDir(
         if (newValue === file.attrs.name) {
           return;
         }
-        file.rename(newValue, errs.handler);
+        return $scope.FPC.actions.rename(file, newValue);
       };
 
       $scope.actions.focusInputElement = function () {

--- a/test/unit/controllers/filePopoverController.unit.js
+++ b/test/unit/controllers/filePopoverController.unit.js
@@ -1,5 +1,5 @@
 'use strict';
-describe('directiveFileTreeDir'.bold.underline.blue, function () {
+describe('FilePopoverController'.bold.underline.blue, function () {
   var FPC;
   var $controller;
   var $rootScope;
@@ -120,6 +120,19 @@ describe('directiveFileTreeDir'.bold.underline.blue, function () {
         sinon.assert.calledOnce(createFsMock);
         sinon.assert.calledWith(createFsMock, dirMock, {isDir: true});
         sinon.assert.calledOnce(closePopoverSpy);
+        sinon.assert.notCalled(errs.handler);
+      });
+    });
+
+    describe('rename', function () {
+      it('should call rename on the element', function () {
+        dirMock.rename = sinon.spy(function (value, cb) {
+          cb(null);
+        });
+        FPC.actions.rename(dirMock, 'hello');
+
+        sinon.assert.calledOnce(dirMock.rename);
+        expect('hello').to.equal(dirMock.rename.args[0][0]);
         sinon.assert.notCalled(errs.handler);
       });
     });

--- a/test/unit/directives/directiveFileTreeDir.unit.js
+++ b/test/unit/directives/directiveFileTreeDir.unit.js
@@ -53,9 +53,16 @@ describe('directiveFileTreeDir'.bold.underline.blue, function () {
       activeCommit: sinon.spy(),
       branchCommits: sinon.spy()
     };
+    var FilePopoverController = function () {
+      this.actions = {
+        rename: sinon.spy()
+      };
+      ctx.mockFilePopoverController = this;
+    };
     createFsMock = sinon.spy();
     angular.mock.module('app');
-    angular.mock.module(function ($provide) {
+    angular.mock.module(function ($provide, $controllerProvider) {
+      $controllerProvider.register('FilePopoverController', FilePopoverController);
       $provide.value('helperCreateFSpromise', createFsMock);
       $provide.value('errs', errs);
       $provide.value('Upload', uploadMock);
@@ -112,8 +119,9 @@ describe('directiveFileTreeDir'.bold.underline.blue, function () {
       $elScope.dir.rename = sinon.spy();
       inputElement.value = '123';
       $elScope.actions.closeFolderNameInput();
-      expect($elScope.dir.rename.calledOnce).to.equal(true);
-      expect($elScope.dir.rename.calledWith('123', errs.handler)).to.equal(true);
+
+      sinon.assert.calledOnce(ctx.mockFilePopoverController.actions.rename);
+      sinon.assert.calledWith(ctx.mockFilePopoverController.actions.rename, $elScope.dir, '123');
     });
 
     it('should trigger close if the user hits enter', function () {
@@ -513,7 +521,8 @@ describe('directiveFileTreeDir'.bold.underline.blue, function () {
         }
       };
       $elScope.actions.closeFileNameInput(event, file);
-      expect(file.rename.calledOnce).to.equal(true);
+      sinon.assert.calledOnce(ctx.mockFilePopoverController.actions.rename);
+      sinon.assert.calledWith(ctx.mockFilePopoverController.actions.rename, file, 'Bar');
     });
 
     it('should not change the file name if it has not been modified', function () {


### PR DESCRIPTION
If you create a file in a build container, then later, try to rename it, it wouldn't save the change.

Added loadingPromises to the rename call
moving the actual renaming to the controller.... where it should be
