### PR TITLE
San 2374 rebuild with cache if build failed

### DIFF
--- a/client/directives/environment/modals/forms/formLogs/viewFormLogs.jade
+++ b/client/directives/environment/modals/forms/formLogs/viewFormLogs.jade
@@ -18,7 +18,7 @@
     SMC.name === 'setupServerModal' && \
     !SMC.isBuilding && \
     !SMC.isDirty() && \
-    SMC.instance && SMC.instance.status() === 'buildFailed' \
+    SMC.instance.status() === 'buildFailed' \
   "
 ) Having build problems? Some errors can be resolved by rebuilding the container.
   button.btn.btn-xxs.orange(


### PR DESCRIPTION
This is only one commit and adds a new "Rebuild Without Cache" button to the logs page in `newContainerFlow`.

![screen shot 2015-10-16 at 11 43 36 am](https://cloud.githubusercontent.com/assets/1981198/10550326/340a6f7e-73fb-11e5-8f8f-48e552ab1df6.png)
