### PR TITLE
Fix for setup modal lingering too long

### DIFF
--- a/client/directives/environment/modals/modalSetupServer/setupServerModalController.js
+++ b/client/directives/environment/modals/modalSetupServer/setupServerModalController.js
@@ -262,10 +262,8 @@ function SetupServerModalController (
   };
 
   SMC.createServerAndClose = function () {
-    return SMC.createServer()
-      .then(function () {
-        close();
-      });
+    close();
+    return SMC.createServer();
   };
 
   SMC.selectRepo = function (repo) {


### PR DESCRIPTION
Call close immediately, instead of waiting for the promise to resolve
