### PR TITLE
Missing 'Update to master config' option in container status popover

### DIFF
--- a/client/directives/components/containerStatusButton/containerStatusOptionsPopoverView.jade
+++ b/client/directives/components/containerStatusButton/containerStatusOptionsPopoverView.jade
@@ -8,7 +8,7 @@
   .popover-content
     //- if build files are out of date
     .well.well-popover.orange.text-center(
-        ng-if = "CSBC.shouldShowUpdateConfigsPrompt"
+        ng-if = "CSBC.instance.configStatusValid && !CSBC.instance.cachedConfigStatus"
     ) This container’s configuration has changed since the current build.
       button.btn.btn-xs.orange(
         ng-click = "actions.updateConfigToMatchMaster()"


### PR DESCRIPTION
forgot to update this check in the popover
