### PR TITLE
SAN-2886 Fix bug where you could delete a container before it's been created

### DIFF
--- a/client/directives/environment/environmentBody/serverStatusCardHeaderView.jade
+++ b/client/directives/environment/environmentBody/serverStatusCardHeaderView.jade
@@ -3,7 +3,8 @@ div(
     'btn': !$root.featureFlags.cardStatus,\
     'btn-sm': !$root.featureFlags.cardStatus,\
     'btn-title': !$root.featureFlags.cardStatus,\
-    'white': !$root.featureFlags.cardStatus && !inModal\
+    'white': !$root.featureFlags.cardStatus && !inModal,\
+    'no-touching': noTouching\
   }"
   pop-over
   pop-over-actions = "popoverServerActions"


### PR DESCRIPTION
Fixed a bug where no-touching was missing when the dropdown couldn't be clicked.
