### PR TITLE
remove padding from build logs (bottom)

### DIFF
--- a/client/assets/styles/scss/components/logs.scss
+++ b/client/assets/styles/scss/components/logs.scss
@@ -125,7 +125,7 @@
 
 // logs scroll horizontally
 .build-log-content {
-  padding: 9px 9px 15px 24px;
+  padding: 9px 9px 0 24px;
   transition: height .15s;
   word-wrap: normal;
 


### PR DESCRIPTION
Before:
<img width="754" alt="screen shot 2015-10-30 at 6 31 29 pm" src="https://cloud.githubusercontent.com/assets/5341618/10861157/78fa09ca-7f34-11e5-94ff-b05ea62963c2.png">

After:
<img width="755" alt="screen shot 2015-10-30 at 6 30 50 pm" src="https://cloud.githubusercontent.com/assets/5341618/10861150/62c88d98-7f34-11e5-9414-2bea43b41298.png">
