### PR TITLE
Fix File Explorer overlapping Repositories section in Safari

### DIFF
--- a/client/assets/styles/scss/layout/instance-sidebar.scss
+++ b/client/assets/styles/scss/layout/instance-sidebar.scss
@@ -128,6 +128,7 @@
 }
 
 .sidebar-section {
+  flex: 0 0 auto;
   margin: 0 12px;
 
   + .sidebar-section {


### PR DESCRIPTION
<img width="353" alt="screen shot 2015-11-18 at 1 32 20 pm" src="https://cloud.githubusercontent.com/assets/7440805/11255029/e10e7884-8df8-11e5-8793-92e3c0120e70.png">

<img width="355" alt="screen shot 2015-11-18 at 1 32 36 pm" src="https://cloud.githubusercontent.com/assets/7440805/11255034/e54817ac-8df8-11e5-95fb-6cde8ba87e90.png">
