### PR TITLE
Add case for when in setting up container in insert hostnames

### DIFF
--- a/client/directives/environment/modals/forms/formEnvironmentVariables/viewFormEnvironmentVariables.jade
+++ b/client/directives/environment/modals/forms/formEnvironmentVariables/viewFormEnvironmentVariables.jade
@@ -16,7 +16,7 @@
 //- table actions
 .table-actions.clearfix(
   ng-class = "{'in': SMC.state.showHostName}"
-  ng-if = "SMC.data.instances.models.length >= 2"
+  ng-if = "(!SMC.instance && SMC.data.instances.models.length >= 1) || SMC.data.instances.models.length >= 2"
   ng-include = "'viewEnvironmentVariableActions'"
 )
 


### PR DESCRIPTION
This line is necessary because when setting up a container, the container being added is not part of `SMC.data.instances.models`.
