### PR TITLE
Add forceRebuild option to 'Rebuild without cache' button

### DIFF
--- a/client/directives/environment/modals/forms/formLogs/viewFormLogs.jade
+++ b/client/directives/environment/modals/forms/formLogs/viewFormLogs.jade
@@ -22,7 +22,7 @@
   "
 ) Having build problems? Some errors can be resolved by rebuilding the container.
   button.btn.btn-xxs.orange(
-    ng-click = "SMC.rebuild(true)"
+    ng-click = "SMC.rebuild(true, true)"
   ) Rebuild Without Cache
 
 //- tabs

--- a/client/directives/environment/modals/modalSetupServer/setupServerModalController.js
+++ b/client/directives/environment/modals/modalSetupServer/setupServerModalController.js
@@ -270,9 +270,9 @@ function SetupServerModalController(
       });
   }
 
-  SMC.rebuild = function (noCache) {
+  SMC.rebuild = function (noCache, forceRebuild) {
     loading(SMC.name, true);
-    return SMC.rebuildAndOrRedeploy(noCache)
+    return SMC.rebuildAndOrRedeploy(noCache, forceRebuild)
       .then(function () {
         return SMC.resetStateContextVersion(SMC.instance.contextVersion, true);
       })


### PR DESCRIPTION
Fixes this issue (or at least some important parts of it).

Steps to replicate: 
1. Create a container in the UI
2. Write a command that will fail.
3. Go to 'logs'
4. Press "Rebuild without cache" (once your build has failed)

If you do this in `master`, it will immediately fail again (it's getting the deduped version).
If you do this in my branch it will start rebuilding from scratch again.
