### PR TITLE
SAN-3055 - DNS Popover

### DIFF
--- a/client/directives/instances/instance/instanceHeaderView.jade
+++ b/client/directives/instances/instance/instanceHeaderView.jade
@@ -60,7 +60,7 @@
   )
 
   //- dns button
-  button.btn.btn-sm.btn-dns(
+  .btn.btn-sm.btn-dns(
     dns-configuration
     instance = "instance"
   )


### PR DESCRIPTION
Fixed bug where in firefox the DNS popover wouldn't trigger on firefox.

This has something to do with the button.
