### PR TITLE
Add caching to services in serviceFetch

### DIFF
--- a/client/services/serviceFetch.js
+++ b/client/services/serviceFetch.js
@@ -419,11 +419,11 @@ function fetchGithubOrgId(
   keypather
 ) {
   var githubOrgIdCache = {};
-  return function (orgNameOrId) {
-    if (!githubOrgIdCache[orgNameOrId]) {
-      githubOrgIdCache[orgNameOrId] = $http({
+  return function (orgName) {
+    if (!githubOrgIdCache[orgName]) {
+      githubOrgIdCache[orgName] = $http({
         method: 'get',
-        url: configAPIHost + '/github/orgs/' + orgNameOrId
+        url: configAPIHost + '/github/orgs/' + orgName
       })
         .then(function (orgObject) {
           if (keypather.get(orgObject, 'data.id')) {
@@ -432,7 +432,7 @@ function fetchGithubOrgId(
           return $q.reject('No Github organization found for org name provided');
         });
     }
-    return githubOrgIdCache[orgNameOrId];
+    return githubOrgIdCache[orgName];
   };
 }
 

--- a/test/unit/services/serviceFetch.unit.js
+++ b/test/unit/services/serviceFetch.unit.js
@@ -1036,6 +1036,7 @@ describe('serviceFetch'.bold.underline.blue, function () {
     var orgId1 = 1;
     var orgName2 = 'Runnable';
     var orgId2 = 2;
+    var $httpStub;
     var fetchOrgsResponse = {
       models: [
         { attrs: generateGithubOrgObject(orgName1, orgId1) },
@@ -1049,10 +1050,11 @@ describe('serviceFetch'.bold.underline.blue, function () {
     beforeEach(function () {
       angular.mock.module('app');
       angular.mock.module(function ($provide) {
-        $provide.factory('fetchOrgs', function ($q) {
-          return function () {
-            return $q.when(fetchOrgsResponse);
+        $provide.factory('$http', function ($q) {
+          $httpStub = function () {
+            return $q.when({ data: { id: orgId1 }});
           };
+          return $httpStub;
         });
       });
       angular.mock.inject(function (
@@ -1066,18 +1068,12 @@ describe('serviceFetch'.bold.underline.blue, function () {
 
     it('should fetch the correct github ID for a given github organization name', function () {
       var result1;
-      var result2;
       fetchGithubOrgId(orgName1)
         .then(function (res) {
           result1 = res;
         });
-      fetchGithubOrgId(orgName2)
-        .then(function (res) {
-          result2 = res;
-        });
       $rootScope.$digest();
       expect(result1).to.equal(orgId1);
-      expect(result2).to.equal(orgId2);
     });
 
     it('should return a reject promise if there is no org with that name', function () {


### PR DESCRIPTION
This used to be in `SAN-3125-add-invite-link-in-commit-view` but it's probably better off in its own PR. 

Cache queries in `serviceFetch`. 

> This must be super old.... lately we just cache the promise, which is definitely the superior way, since it prevents simultaneous calls. Mind switching this to do that?

Fixed.
