### PR TITLE
SAN-3195 Fix Dir Uploads

### DIFF
--- a/client/directives/components/explorer/explorerDirective.js
+++ b/client/directives/components/explorer/explorerDirective.js
@@ -22,7 +22,8 @@ function explorer() {
       editExplorer: '=?',
       loadingPromisesTarget: '@?',
       readOnly: '=?',
-      debugContainer: '=?'
+      debugContainer: '=?',
+      dir: '=rootDir'
     },
     link: function ($scope) {
       $scope.state = {};
@@ -36,7 +37,6 @@ function explorer() {
       };
 
       $scope.$watch('rootDir', function (rootDir) {
-        $scope.dir = $scope.rootDir;
         if (!rootDir) { return; }
         initRootDirState(rootDir);
       });


### PR DESCRIPTION
When rootDir changes we need to update the value of dir, this is used in the filePopover controller.
- [ ] Reviewer 1
