### PR TITLE
Add URL to Could not reach server error

### DIFF
--- a/client/services/serviceApiClientBridge.js
+++ b/client/services/serviceApiClientBridge.js
@@ -83,7 +83,11 @@ methods.forEach(function (method) {
 
       if (status === 0) {
         // CORS failed
-        return cb(new Error('Could not reach server URL: ' + opts.url));
+        self.report.debug('Could not reach server. \nJSON: '  + JSON.stringify(opts, false, 2), {
+          emitter: 'Manual',
+          source: 'client/services/serviceUser.js'
+        });
+        return cb(new Error('Could not reach server'));
       }
       var body = data;
       var res = {


### PR DESCRIPTION
Currently, we're getting a lot of "Could not reach server" errors in Rollbar, but we don't know what endpoint could not be reached. 
