### PR TITLE
Adding DebugContainer flag to the terminal stream connection message

### DIFF
--- a/client/directives/activePanel/tabs/logs/termController.js
+++ b/client/directives/activePanel/tabs/logs/termController.js
@@ -29,7 +29,7 @@ function TermController(
     } else if ($scope.debugContainer) {
       streamModel = $scope.debugContainer.attrs.inspect;
     }
-    var streams = primus.createTermStreams(streamModel, uniqueId);
+    var streams = primus.createTermStreams(streamModel, uniqueId, !!$scope.debugContainer);
     uniqueId = streams.uniqueId;
     $scope.stream = streams.termStream;
     $scope.eventStream = streams.eventStream;

--- a/client/services/servicePrimus.js
+++ b/client/services/servicePrimus.js
@@ -51,7 +51,7 @@ RunnablePrimus.prototype.createBuildStream = function (build) {
   }
 };
 
-RunnablePrimus.prototype.createTermStreams = function (container, uniqueId) {
+RunnablePrimus.prototype.createTermStreams = function (container, uniqueId, isDebugContainer) {
   container = container.json ? container.json() : container;
   var streamId = container.dockerContainer;
   if (!uniqueId) {
@@ -63,6 +63,7 @@ RunnablePrimus.prototype.createTermStreams = function (container, uniqueId) {
     data: {
       dockHost: container.dockerHost,
       type: 'filibuster',
+      isDebugContainer: isDebugContainer,
       containerId: container.dockerContainer,
       terminalStreamId: uniqueId,
       eventStreamId: uniqueId + 'events'

--- a/test/unit/controllers/termController.unit.js
+++ b/test/unit/controllers/termController.unit.js
@@ -41,13 +41,20 @@ describe('TermController'.bold.underline.blue, function () {
         ]
       }
     };
+    ctx.debugContainer = {
+      attrs: apiMocks.instances.running.containers[0]
+    };
     $controller('TermController', {
       '$scope': $scope
     });
   }
   describe('basics'.blue, function () {
+    beforeEach(setup);
     beforeEach(function () {
-      setup();
+      sinon.spy(mockPrimus, 'createTermStreams');
+    });
+    afterEach(function () {
+      mockPrimus.createTermStreams.restore();
     });
     it('should not set anything up without a valid instance on the scope', function () {
       var streamStartListener = sinon.spy();
@@ -74,6 +81,13 @@ describe('TermController'.bold.underline.blue, function () {
       $scope.$digest();
       expect($scope.stream, 'stream').to.be.ok;
       expect($scope.eventStream, 'eventsStream').to.be.ok;
+      sinon.assert.calledOnce(mockPrimus.createTermStreams);
+      sinon.assert.calledWith(
+        mockPrimus.createTermStreams,
+        ctx.instance.containers.models[0],
+        sinon.match.any,
+        false
+      );
     });
     it('should connect the stream when requested', function () {
       $rootScope.$digest();
@@ -87,6 +101,25 @@ describe('TermController'.bold.underline.blue, function () {
       $rootScope.$digest();
       sinon.assert.calledOnce($scope.stream.on);
       sinon.assert.calledOnce(term.on);
+    });
+    it('should create the debug container stream', function () {
+      $scope.debugContainer = ctx.debugContainer;
+      $rootScope.$digest();
+      expect($scope.stream, 'stream').to.not.be.ok;
+      expect($scope.eventStream, 'eventsStream').to.not.be.ok;
+      expect($scope.createStream, 'createStream').to.be.ok;
+      $scope.createStream();
+      $rootScope.$digest();
+      $scope.$digest();
+      expect($scope.stream, 'stream').to.be.ok;
+      expect($scope.eventStream, 'eventsStream').to.be.ok;
+      sinon.assert.calledOnce(mockPrimus.createTermStreams);
+      sinon.assert.calledWith(
+        mockPrimus.createTermStreams,
+        ctx.debugContainer.attrs.inspect,
+        sinon.match.any,
+        true
+      );
     });
   });
 


### PR DESCRIPTION
Adding a flag into the socket message used to connect terminal connections that specifies if this is a debug container or not
