### PR TITLE
Add loading state. Fix showErrorPanel when there's no error

### DIFF
--- a/client/directives/components/buildLogs/buildLogsController.js
+++ b/client/directives/components/buildLogs/buildLogsController.js
@@ -3,21 +3,23 @@
 require('app').controller('BuildLogsController', BuildLogsController);
 
 function BuildLogsController(
-  streamingLog,
   $scope,
-  primus,
   $rootScope,
   $timeout,
-  launchDebugContainer,
-  updateInstanceWithNewBuild,
   errs,
-  promisify
+  launchDebugContainer,
+  loading,
+  updateInstanceWithNewBuild,
+  primus,
+  promisify,
+  streamingLog
 ) {
   var BLC = this;
   BLC.showDebug = false;
 
   function handleUpdate () {
     var status = BLC.instance.status();
+    BLC.showErrorPanel = false;
     if (status === 'buildFailed' || status === 'neverStarted') {
       BLC.buildStatus = 'failed';
       BLC.showDebug = true;
@@ -114,6 +116,7 @@ function BuildLogsController(
       );
     },
     rebuildWithoutCache: function () {
+      loading('buildLogsController', true);
       promisify(BLC.instance.build, 'deepCopy')()
         .then(function (build) {
           return updateInstanceWithNewBuild(
@@ -122,7 +125,10 @@ function BuildLogsController(
             true
           );
         })
-        .catch(errs.handler);
+        .catch(errs.handler)
+        .finally(function () {
+           loading('buildLogsController', false);
+        });
     },
     launchDebugContainer: function (event, command) {
       if (BLC.debugContainer) {

--- a/client/directives/components/buildLogs/buildLogsView.jade
+++ b/client/directives/components/buildLogs/buildLogsView.jade
@@ -1,15 +1,23 @@
 .blank-panel(
   ng-if = "$root.featureFlags.noBuildLogs && (hasFailedAndHasNoLogs() || BLC.showErrorPanel)"
 )
-  p.p Sorry, we ran into an issue trying to build your container.
-  button.btn.btn-sm.purple(
-    ng-click = "BLC.actions.rebuildWithoutCache()"
-  ) Retry Build
-  .small
-    | or&#32;
-    a.link(
-      ng-click = "BLC.actions.openIntercom()"
-    ) chat with a dev
+  .spinner-wrapper.spinner-md.in(
+    ng-if = "$root.isLoading.buildLogsController"
+    ng-include = "'spinner'"
+  )
+
+  div(
+    ng-if = "!$root.isLoading.buildLogsController"
+  )
+    p.p Sorry, we ran into an issue trying to build your container.
+    button.btn.btn-sm.purple(
+      ng-click = "BLC.actions.rebuildWithoutCache()"
+    ) Retry Build
+    .small
+      | or&#32;
+      a.link(
+        ng-click = "BLC.actions.openIntercom()"
+      ) chat with a dev
 
 .pre.build-log(
   ng-if = "\


### PR DESCRIPTION
Add loading state to this view:

![screen shot 2016-01-19 at 3 50 41 pm](https://cloud.githubusercontent.com/assets/1981198/12435760/6dc5f22e-bec4-11e5-89f6-614a36c7d951.png)

To test: 
1. Get an instance (I use `$scope.instance with the Angular Chrome plugin) 
2. Set the `instance.status` method to the following `function () { return 'neverStarted' };` while saving original method somewhere else `instance.realStatus = instance.status`.
3. Go into another instance and return to that instance
4. Make sure you see the rebuild button. 
5. Press the button

Expected: It should show the loading state and quickly revert back to the retry build view. If you revert the `status` method, then you'll see the logs.

Fixes: https://runnable.atlassian.net/browse/SAN-3211
