### PR TITLE
fix environment notification width

### DIFF
--- a/client/assets/styles/scss/layout/environment.scss
+++ b/client/assets/styles/scss/layout/environment.scss
@@ -42,7 +42,7 @@
     right: 0;
     text-align: center;
     top: 9px;
-    width: 160px;
+    width: 161px;
   }
 
   .iconnables {


### PR DESCRIPTION
- [x] @runnabro

This fixes a bug that only happens in Safari when a modal is open. You can comment out the alert logic in `environmentView.jade` to test it.

before:
![image](https://cloud.githubusercontent.com/assets/7440805/12690757/b0f513b2-c69a-11e5-9fef-9a2428f1731f.png)

after:
![image](https://cloud.githubusercontent.com/assets/7440805/12690760/b4b50908-c69a-11e5-9cfe-896dbb3ce5ca.png)
