### PR TITLE
fix broken rebuild button

### DIFF
--- a/client/directives/components/containerStatusButton/containerStatusOptionsPopoverView.jade
+++ b/client/directives/components/containerStatusButton/containerStatusOptionsPopoverView.jade
@@ -38,7 +38,7 @@
           actions.updateConfigToMatchMaster() : \
           actions.rebuildWithoutCache() \
         "
-        ng-if = "!CSBC.instance.configStatusValid && !CSBC.instance.cachedConfigStatus)"
+        ng-if = "!CSBC.instance.configStatusValid && !CSBC.instance.cachedConfigStatus"
       )
         .icons-status.orange
         | Rebuild Without Cache


### PR DESCRIPTION
We previously modified the "rebuild without cache" button to always use the function that updates the config. This broke rebuilds in cases where no new config existed. This update only uses that function when a new config exists.
