### PR TITLE
Runnable-Cache set at start, not reflected in UI

### DIFF
--- a/client/directives/environment/modals/forms/formRepository/repositoryFormDirective.js
+++ b/client/directives/environment/modals/forms/formRepository/repositoryFormDirective.js
@@ -26,15 +26,19 @@ require('app')
         $scope.data = {
           cacheCommand: false
         };
+        function checkForCacheCommand() {
+          // Use every because it will short circuit when it finds something that returns false
+          $scope.data.cacheCommand = !$scope.state.mainRepoContainerFile.commands.every(function (cmd) {
+            return !cmd.cache;
+          });
+        }
         watchOncePromise($scope, 'state.containerFiles', true)
           .then(function (containerFiles) {
             $scope.state.mainRepoContainerFile = containerFiles.find(function (containerFile) {
               return containerFile.type === 'Main Repository';
             });
             $scope.state.mainRepoContainerFile.commands = $scope.state.mainRepoContainerFile.commands || [];
-            $scope.data.cacheCommand = $scope.state.mainRepoContainerFile.commands.some(function (cmd) {
-              return cmd.cache;
-            });
+            checkForCacheCommand();
             // Clear out the start command (only in setup, but this will change)
             if ($scope.startCommandCanDisable && $scope.state.mainRepoContainerFile) {
               $scope.$watch('state.selectedStack.key', function (newStackKey, oldStackKey) {
@@ -56,6 +60,7 @@ require('app')
                         return new cardInfoTypes.Command('RUN ' + run);
                       });
                       $scope.state.mainRepoContainerFile.path = (defaults.dst.length ? defaults.dst[0] : repoName).replace('/', '');
+                      checkForCacheCommand();
                     })
                     .catch(report.error);
                 }

--- a/test/unit/environment/repositoryFormDirective.unit.js
+++ b/test/unit/environment/repositoryFormDirective.unit.js
@@ -349,5 +349,28 @@ describe('repositoryFormDirective'.bold.underline.blue, function () {
       expect($elScope.state.containerFiles[0].commands[1].body, 'main repo command 0').to.equal('dsfasdfredasfadsfgw34r2 3r');
       expect($elScope.state.containerFiles[0].path, 'main repo path').to.equal('cheese');
     });
+
+    it('should fetch default commands with runnable-cache, and update scope.data.cacheCommand', function () {
+      ctx.parseDockerfileResults = {
+        run: ['dfadsfa # runnable-cache', 'dsfasdfredasfadsfgw34r2 3r'],
+        dst: []
+      };
+      $elScope.state.selectedStack = {
+        key: 'hello'
+      };
+      $elScope.state.opts = {
+        name: 'cheese'
+      };
+      $scope.$digest();
+      var dockerfile = {attrs: 'dockerfile'};
+
+      ctx.fetchDockerfileFromSourceMock.triggerPromise(dockerfile);
+      $scope.$digest();
+
+      expect($elScope.state.containerFiles[0].commands[0].body, 'main repo command 0').to.equal('dfadsfa');
+      expect($elScope.state.containerFiles[0].commands[0].cache, 'main repo command 0 cache').to.be.true;
+      expect($elScope.state.containerFiles[0].commands[1].body, 'main repo command 1').to.equal('dsfasdfredasfadsfgw34r2 3r');
+      expect($elScope.cacheCommand(), 'cache command').to.be.true;
+    });
   });
 });


### PR DESCRIPTION
To test this, you'll need to make sure the source dockerfile you are using has runnable-cache on one of the default commands in the dockerfile
https://runnable.atlassian.net/browse/SAN-3648
