### PR TITLE
SAN-3874: Error messages from Docker should bubble up to the build logs

### DIFF
--- a/client/services/streamingLogService.js
+++ b/client/services/streamingLogService.js
@@ -31,7 +31,7 @@ function streamingLog(
         dataArray = [dataArray];
       }
       dataArray.forEach(function (data) {
-        if (['docker', 'log'].includes(data.type)) {
+        if (['docker', 'log', 'error'].includes(data.type)) {
           var stepRegex = /^Step [0-9]+ : /;
           if (stepRegex.test(data.content)) {
             if (currentCommand) {


### PR DESCRIPTION
Show all error messages to the user in order to simplify error handling.
- [x] @Myztiq 
