### PR TITLE
fix intercom layout bugs

### DIFF
--- a/client/assets/styles/scss/components/external/intercom.scss
+++ b/client/assets/styles/scss/components/external/intercom.scss
@@ -84,11 +84,15 @@
     }
   }
 
-  .modal-backdrop {
+  .modal-backdrop.modal-backdrop {
     padding-left: $intercom-width + 15px;
 
     @include media(md) {
-      padding-left: 0;
+      padding-left: 15px;
+    }
+
+    @media (max-height: $screen-xs), (max-width: $screen-sm) {
+      padding: 15px;
     }
   }
 


### PR DESCRIPTION
- fix help cards being offset when intercom was open
- fix modals being off by 15px on the left when intercom was open
- fix modals inheriting non-responsive padding at small sizes with intercom open
