### PR TITLE
Isolation DNS (just apiclient and hostname)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "101": "0.14.1",
-    "@runnable/api-client": "git://github.com/Runnable/api-client.git#dynamic-isolation-urls",
+    "@runnable/api-client": "^7.0.0",
     "angular": "1.3.15",
     "angular-animate": "1.3.15",
     "angular-clipboard": "^1.1.1",


### PR DESCRIPTION
This PR just ups the version of ApiClient and Hostname

STILL REQUIRES 
- [x] - https://github.com/Runnable/api-client/pull/5

DO NOT change the dns connection in the connections drop down.  That will break the dns since you can't reselect it yet.  That will be a different UI PR
- [x] @thejsj
