### PR TITLE
Add showStackSelector method to editServerModalController

### DIFF
--- a/client/directives/environment/modals/modalEditServer/editServerModalController.js
+++ b/client/directives/environment/modals/modalEditServer/editServerModalController.js
@@ -142,6 +142,10 @@ function EditServerModalController(
       });
   }
 
+  SMC.showStackSelector = function () {
+    return !SMC.state.advanced;
+  };
+
   SMC.startCommand = function () {
     var cmd = keypather.get(SMC, 'instance.containers.models[0].attrs.inspect.Config.Cmd[2]');
     return cleanStartCommand(cmd);


### PR DESCRIPTION
Fixes stack selector not showing up in `editServerModalController`

![screen shot 2016-05-02 at 2 22 47 pm](https://cloud.githubusercontent.com/assets/1981198/14968727/504c10a6-1073-11e6-8559-b3b081c43d6f.png)
### Reviewers
- [x] Reviewer 1
