### PR TITLE
Update grunt-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "grunt-contrib-uglify": "^0.9.2",
     "grunt-jade-plugin": "git://github.com/Runnable/grunt-jade-plugin.git#604fba490db0c8cf9ee4ce0c51ef91acf44ac573",
     "grunt-newer": "^1.1.1",
-    "grunt-sass": "1.0.0",
+    "grunt-sass": "1.1.0",
     "grunt-timer": "0.6.0",
     "jade": "1.11.0",
     "js-base64": "^2.1.9",


### PR DESCRIPTION
Fixes deployment issue where `node-sass` causes build to crash. Same issue we saw on marketing site.
