### PR TITLE
Fix for deleting Container Files

### DIFF
--- a/client/directives/environment/modals/forms/formFiles/containerFilesController.js
+++ b/client/directives/environment/modals/forms/formFiles/containerFilesController.js
@@ -164,28 +164,30 @@ function ContainerFilesController(
         $rootScope.$broadcast('close-popovers');
         return loadingPromises.add(
           'editServerModal',
-          $q(function (resolve) {
-            if (containerFile.fileModel) {
-              return resolve(containerFile.fileModel);
-            }
-            return promisify(self.state.contextVersion.rootDir.contents, 'fetch')()
-              .then(function () {
-                var file =  self.state.contextVersion.rootDir.contents.models.find(function (fileModel) {
-                  return fileModel.attrs.name === containerFile.name;
-                });
-                resolve(file);
-              });
-          })
-            .then(function (file) {
-              var containerIndex = self.state.containerFiles.indexOf(containerFile);
-              if (containerIndex > -1) {
-                self.state.containerFiles.splice(containerIndex, 1);
+          $q.when()
+            .then(function () {
+              if (containerFile.fileModel) {
+                return containerFile.fileModel;
               }
+              return promisify(self.state.contextVersion.rootDir.contents, 'fetch')()
+                .then(function () {
+                  return self.state.contextVersion.rootDir.contents.models.find(function (fileModel) {
+                    return fileModel.attrs.name === containerFile.name;
+                  });
+                });
+            })
+            .then(function (file) {
               if (file) {
                 return promisify(file, 'destroy')()
                   .then(function () {
                     return promisify(self.state.contextVersion.rootDir.contents, 'fetch')();
                   });
+              }
+            })
+            .then(function () {
+              var containerIndex = self.state.containerFiles.indexOf(containerFile);
+              if (containerIndex > -1) {
+                self.state.containerFiles.splice(containerIndex, 1);
               }
             })
             .then(function () {

--- a/test/unit/controllers/containerFilesController.unit.js
+++ b/test/unit/controllers/containerFilesController.unit.js
@@ -84,7 +84,7 @@ describe('ContainerFilesController'.bold.underline.blue, function () {
         },
         rootDir: {
           contents: {
-            create: sinon.spy(),
+            create: sinon.stub().returns(),
             fetch: sinon.stub().returns()
           }
         }


### PR DESCRIPTION
I noticed that because the file editor isn't loaded on creation, the rootDir folder wasn't getting fetched/

Now the delete's will fetch beforehand, if they need to
### Reviewers
- [x] @thejsj
