### PR TITLE
fix back button in new services modal

### DIFF
--- a/client/directives/components/mirrorDockerfile/mirrorDockerfileView.jade
+++ b/client/directives/components/mirrorDockerfile/mirrorDockerfileView.jade
@@ -10,7 +10,7 @@
   p.p.text-center We couldn’t find a Dockerfile in this repository.
 
 .grid-content.shrink.list.list-bordered(
-  ng-if = "!MDC.fromTool && !$root.isLoading.mirrorDockerfile"
+  ng-if = "!MDC.fromTool"
 )
   //- add .disabled class to the not selected item if loading
   label.grid-block.list-item(

--- a/client/directives/modals/modalNewContainer/newContainerModalView.jade
+++ b/client/directives/modals/modalNewContainer/newContainerModalView.jade
@@ -102,7 +102,7 @@
       )
         header.modal-header
           svg.iconnables.icons-arrow-backward(
-            ng-click = "!$root.isLoading[MC.name + 'SingleRepo'] && goToPanel('dockerfileMirroring', 'back')"
+            ng-click = "!$root.isLoading[MC.name + 'SingleRepo'] && goToPanel(MC.state.templateSource ? 'containerSelection' : 'dockerfileMirroring', 'back')"
           )
             use(
               xlink:href = "#icons-arrow-down"


### PR DESCRIPTION
Don't hide "New Configuration" option while fetching dockerfile
fix back button in new services modal
