### PR TITLE
San 4754 fix dockerfile display bug

### DIFF
--- a/client/directives/components/mirrorDockerfile/mirrorDockerfileController.js
+++ b/client/directives/components/mirrorDockerfile/mirrorDockerfileController.js
@@ -11,7 +11,6 @@ function MirrorDockerfileController(
   fetchRepoDockerfiles,
   keypather
 ) {
-
   var MDC = this;
   if (!MDC.repo) {
     throw new Error('A repo is required for this controller');


### PR DESCRIPTION
The mirror dockerfile directive to show available docker files in a repo would not display any dockerfiles if a repo without one was previously selected because the fullRepo property was set once at instantiation and would not display dockerfiles if found as a result.
