### PR TITLE
Limit suggested versions to match one version, removed hack for ruby …

### DIFF
--- a/client/directives/environment/modals/forms/formStack/viewFormStackSelector.jade
+++ b/client/directives/environment/modals/forms/formStack/viewFormStackSelector.jade
@@ -79,7 +79,7 @@
       ng-if = "$parent.state.selectedStack.suggestedVersion"
     ) Suggested {{$parent.$parent.state.selectedStack.name}} Version
     fancy-option(
-      ng-repeat = "version in $parent.state.selectedStack.versions | filter: $parent.state.selectedStack.suggestedVersion"
+      ng-repeat = "version in $parent.state.selectedStack.versions | filter: $parent.state.selectedStack.suggestedVersion | limitTo: 1"
       value = "version"
     ) {{$parent.version}}
     li.divider(
@@ -107,7 +107,7 @@
       ng-if = "$parent.depStack.suggestedVersion"
     ) Suggested {{$parent.$parent.depStack.name}} Version
     fancy-option(
-      ng-repeat = "version in $parent.depStack.versions | filter: $parent.depStack.suggestedVersion"
+      ng-repeat = "version in $parent.depStack.versions | filter: $parent.depStack.suggestedVersion | limitTo: 1"
       value = "version"
     ) {{$parent.version}}
     li.divider(

--- a/client/services/serviceFetchStackInfo.js
+++ b/client/services/serviceFetchStackInfo.js
@@ -25,15 +25,6 @@ function fetchStackInfo(
                 var depObject = angular.copy(data[dep]);
                 depObject.key = dep;
                 depObject.suggestedVersion = depObject.defaultVersion;
-                if (dep === 'ruby') {
-                  // Fucking hacks.....
-                  ['1.8.6-p420', '1.8.7-p374'].forEach(function (thingThatDoesntBelong) {
-                    var index = depObject.versions.indexOf(thingThatDoesntBelong);
-                    if (index > -1) {
-                      depObject.versions.splice(index, 1);
-                    }
-                  });
-                }
                 return depObject;
               });
             }


### PR DESCRIPTION
This PR fixes an issue where suggestedVersions matches one or many versions in the array by the filter. This also removes the hack for ruby versions in dependencies.
