### PR TITLE
Hotfix Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@runnable/api-client": "v9.1.1",
     "angular": "1.3.15",
     "angular-animate": "1.3.15",
-    "angular-clipboard": "^1.1.1",
+    "angular-clipboard": "1.4.x",
     "angular-credit-cards": "^3.1.4",
     "angular-drag-and-drop-lists": "git://github.com/cmlenz/angular-drag-and-drop-lists.git#handle-support",
     "angular-modal-service": "git://github.com/Runnable/angular-modal-service.git#v0.6.8",

--- a/test/unit/directives/components/containerUrl/containerUrlDirective.unit.js
+++ b/test/unit/directives/components/containerUrl/containerUrlDirective.unit.js
@@ -8,7 +8,6 @@ var $window;
 var keypather;
 var $q;
 var $elScope;
-var readOnlySwitchController;
 var apiMocks = require('./../../../apiMocks/index');
 
 describe('containerUrlDirective'.bold.underline.blue, function () {


### PR DESCRIPTION
Locking version of angular-clipboard to 1.4.x because 1.5 caused errors to be thrown in tests.
- [x] @henrymollman 
- [x] @thejsj 
