### PR TITLE
Fixes issue with undefined appearing as dockerfile path

### DIFF
--- a/client/directives/components/mirrorDockerfile/mirrorDockerfileView.jade
+++ b/client/directives/components/mirrorDockerfile/mirrorDockerfileView.jade
@@ -38,7 +38,7 @@
         )
 
 small.small.text-gray.padding-xxs.label-from(
-  ng-if = "!$root.isLoading.mirrorDockerfile && MDC.state.repo.dockerfiles.length > 0"
+  ng-if = "!$root.isLoading.mirrorDockerfile && MDC.state.repo.dockerfiles.length > 0 && MDC.state.repo.dockerfiles[0].path !== '/undefined'"
 ) Advanced Setup
 
 .grid-content.shrink.list.list-bordered(
@@ -67,7 +67,7 @@ small.small.text-gray.padding-xxs.label-from(
         )
 
 .grid-content.shrink.list.list-bordered(
-  ng-if = "!$root.isLoading.mirrorDockerfile && MDC.state.repo.dockerfiles.length > 0"
+  ng-if = "!$root.isLoading.mirrorDockerfile && MDC.state.repo.dockerfiles.length > 0 && MDC.state.repo.dockerfiles[0].path !== '/undefined'"
 )
   //- 'thisDockerfile' should be the name of the Dockerfile (ie. 'Dockerfile.prod', or 'Dockerfile.staging') to suppot multiple dockerfiles
   //- add .disabled class to the not selected item if loading


### PR DESCRIPTION
This will prevent a path of /undefined from appearing in the configuration modal when creating a new container. The issue stems from an item in the repo model's dockerfile array, but the item only states that the repository is empty and there is an property, 'path' on that item that is just a string, '/undefined'

The bug comes from the absence of a value somewhere on the backend but this fix will prevent that from being seen on the frontend. It will not fix the deeper bug.

This can also be reproduced by building from the "Priest" repo on Runnable or any empty repository.
