### PR TITLE
Prevented terminal from being accessed when the instance is not running

### DIFF
--- a/client/directives/environment/modals/forms/formLogs/viewFormLogs.jade
+++ b/client/directives/environment/modals/forms/formLogs/viewFormLogs.jade
@@ -14,7 +14,7 @@
   button.btn.btn-xs.white(
     ng-class = "{'active': SMC.page === 'terminal'}"
     ng-click = "SMC.page = 'terminal'"
-    ng-disabled = "!SMC.instance.containers.models.length"
+    ng-disabled = "!SMC.instance.containers.models.length && SMC.instance.status() !== 'running'"
     ng-if = "$root.featureFlags.configTerminal"
   ) Terminal
 


### PR DESCRIPTION
This ensures that the instance is in a running state for the terminal to be accessible.
