### PR TITLE
Stop unique events when user clicks buttons.

### DIFF
--- a/client/services/serviceEventTracking.js
+++ b/client/services/serviceEventTracking.js
@@ -311,7 +311,7 @@ EventTracking.prototype.trackClicked = function (data) {
   var self = this;
   self._mixpanel('track', 'clicked - ' + _keypather.get(data, 'text'), data);
   self.analytics.ready(function () {
-    self.analytics.track('Clicked - ' + _keypather.get(data, 'text'), data);
+    self.analytics.track('Click', data);
   });
   return self;
 };


### PR DESCRIPTION
Segment is complaining about us sending them too many unique events, which we're sending because we include the name of the button the user clicks on in the event name.

![image](https://cloud.githubusercontent.com/assets/2469588/18620672/13c56724-7dcc-11e6-8d17-15d079d0d9ea.png)
