### PR TITLE
Fixed issue with blank dockerfile 

### DIFF
--- a/client/directives/environment/modals/serverModalController.js
+++ b/client/directives/environment/modals/serverModalController.js
@@ -42,6 +42,11 @@ function ServerModalController(
 
   this.openDockerfile = function (state, openItems) {
     var SMC = this;
+    if (SMC.state.advanced === 'blankDockerfile') {
+      promisify(SMC.state.contextVersion, 'update')({
+        advanced: true
+      });
+    }
     return fetchDockerfileForContextVersion(state.contextVersion)
       .then(function (dockerfile) {
         if (keypather.get(SMC, 'instance.hasDockerfileMirroring()') && !SMC.instance.mirroredDockerfile) {

--- a/test/unit/controllers/serverModalController.unit.js
+++ b/test/unit/controllers/serverModalController.unit.js
@@ -996,6 +996,16 @@ describe('serverModalController'.bold.underline.blue, function () {
       $scope.$digest();
       expect(SMC.state.dockerfile).to.equal(ctx.anotherDockerfile);
     });
+    
+    it('should update the instance to advanced mode when using a blank dockerfile', function() {
+      SMC.state.advanced = 'blankDockerfile';
+      SMC.openDockerfile(SMC.state, SMC.openItems);
+      $scope.$digest();
+      sinon.assert.calledOnce(SMC.state.contextVersion.update);
+      sinon.assert.calledWith(SMC.state.contextVersion.update, {
+        advanced: true
+      });
+    });
   });
 
   describe('getDisplayName', function () {


### PR DESCRIPTION
Creating a new template would result in a blank dockerfile configuration to not be set to advanced, resulting in 'simple mode' UI.

Tests included
