### PR TITLE
Prevent empty repo from giving undefined dockerfile

### DIFF
--- a/client/services/serviceFetchDockerfile.js
+++ b/client/services/serviceFetchDockerfile.js
@@ -46,7 +46,7 @@ function fetchRepoDockerfiles(
 
 function doesDockerfileExist() {
   return function (file) {
-    if (!file || (file.message && (file.message.match(/not.found/i) || file.message.match(/empty/i)))) {
+    if (!file || (file.message && (file.message.match(/not.found/i) || file.message.match(/This.repository.is.empty/)))) {
       return undefined;
     }
     // GH doesnt return the '/' when returning a path


### PR DESCRIPTION
An empty repository with no dockerfile will have the message, 'This Repository is Empty' which was not picked up by this check.
