### PR TITLE
Fixed bug that would show the wrong color for the error icon

### DIFF
--- a/client/directives/components/ahaGuide/AhaGuideController.js
+++ b/client/directives/components/ahaGuide/AhaGuideController.js
@@ -122,6 +122,7 @@ function AhaGuideController(
     var buildStatus = update.status;
     if (buildStatus === 'buildFailed' || buildStatus === 'stopped' || buildStatus === 'crashed') {
       AGC.showError = true;
+      AGC.errorState = 'nonRunningContainer';
       $rootScope.$broadcast('ahaGuideEvent', {
         error: 'buildFailed'
       });


### PR DESCRIPTION
Changed the error state so that the correct color is shown. Issue was caused by wrong element parent class (aha-meter-100) that was taking stylistic precedence over another state.

https://runnable.atlassian.net/browse/SAN-5096
