### PR TITLE
Setup confirmation modal is too high

### DIFF
--- a/client/assets/styles/scss/modals/modals-confirm-setup.scss
+++ b/client/assets/styles/scss/modals/modals-confirm-setup.scss
@@ -3,9 +3,9 @@
   > .img {
     height: auto;
     position: relative;
+    top: 43px;
     width: 180px;
     z-index: 1;
-    top: 43px;
   }
 
   .modal-dialog {


### PR DESCRIPTION
Changed css styles for setup confirmation modal to move modal 43 pixels below current position. Moved runnabear image as well
