### PR TITLE
stop displaying "collection requires a client"

### DIFF
--- a/client/services/serviceHandleErr.js
+++ b/client/services/serviceHandleErr.js
@@ -24,6 +24,10 @@ function errs (
       $window.location = configAPIHost + '/auth/github?redirect=' + $window.location.protocol + '//' + $window.location.host + '/?auth';
       return false;
     }
+    if (err.message === 'collection requires a client') {
+      // Fuck this error
+      return false;
+    }
 
     if (~noDisplayCodes.indexOf(keypather.get(err, 'data.statusCode'))) { return false; }
     return true;


### PR DESCRIPTION
Just ignore it.  It's useless
