### PR TITLE
add z-index for persistent popovers

### DIFF
--- a/client/assets/styles/scss/popover/popover.scss
+++ b/client/assets/styles/scss/popover/popover.scss
@@ -94,6 +94,11 @@
     }
   }
 
+  // for popovers that don’t dismiss normally
+  &.popover-persistent {
+    z-index: $z-modal-backdrop - 1;
+  }
+
   // empty state
   .empty {
     color: $gray;

--- a/client/directives/instances/instance/branchMenuPopover/introAddBranch.jade
+++ b/client/directives/instances/instance/branchMenuPopover/introAddBranch.jade
@@ -1,4 +1,4 @@
-.popover.menu.right.popover-branch-menu(
+.popover.menu.right.popover-branch-menu.popover-persistent(
   ng-class = "{'in': active}"
   ng-style = "popoverStyle.getStyle()"
 )
@@ -16,7 +16,7 @@
   )
 
   .arrow.white
-  
+
   animated-panel-container.popover-views(
     ng-if = "!$root.featureFlags.autoIsolationSetup && $root.isLoading.fetchingBranches"
   )


### PR DESCRIPTION
Addresses [this bug](https://runnable.atlassian.net/browse/SAN-5062) and [this one](https://runnable.atlassian.net/browse/SAN-5008).

The "add a branch" aha popover and the auto-launch popover (after Runnabot) should no longer cover modals.