### PR TITLE
Prevented solitary users w/out orgs from seeing no accounts

### DIFF
--- a/client/directives/modals/modalChooseOrganization/chooseOrganizationModalController.js
+++ b/client/directives/modals/modalChooseOrganization/chooseOrganizationModalController.js
@@ -38,9 +38,6 @@ function ChooseOrganizationModalController(
   COMC.demoOrg = null;
 
   COMC.defaultBasePanel = 'orgSelection';
-  if (COMC.allAccounts.models.length === 0) {
-    COMC.defaultBasePanel = 'grantAccess';
-  }
 
   COMC.isInDemoFlow = false;
 

--- a/client/directives/modals/modalChooseOrganization/orgSelectModalView.jade
+++ b/client/directives/modals/modalChooseOrganization/orgSelectModalView.jade
@@ -2,7 +2,7 @@
   h1.modal-heading Welcome Aboard!
 
 .grid-block.vertical.padding-sm
-  p.margin-top-sm.margin-bottom-md.p.text-center.weight-light Which team’s code do&#32;
+  p.margin-top-sm.margin-bottom-md.p.text-center.weight-light Whose code do&#32;
     br.visible-xxxs
     | you want to run?
 


### PR DESCRIPTION
Users without any orgs were not able to see their account until they added an org. This has been fixed so that the animated panel does not default to grant access if there are no orgs that have been granted access to a personal user.