### PR TITLE
Fix for new instances in demo flow not autoforking

### DIFF
--- a/client/directives/components/newContainer/newContainerController.js
+++ b/client/directives/components/newContainer/newContainerController.js
@@ -32,7 +32,9 @@ function NewContainerController(
       dockerfile: null,
       configurationMethod: null,
       namesForAllInstances: [],
-      opts: {}
+      opts: {
+        shouldNotAutofork: keypather.get(currentOrg, 'poppa.attrs.metadata.hasCompletedDemo')
+      }
     },
     ahaGuide: ahaGuide
   });


### PR DESCRIPTION
Non-demo instances would have shouldNotAutoFork property set to true without this addition