### PR TITLE
Return buttons to confirmation modal

### DIFF
--- a/client/directives/modals/gracePeriodModal/expiredAccountController.js
+++ b/client/directives/modals/gracePeriodModal/expiredAccountController.js
@@ -4,14 +4,16 @@ require('app')
   .controller('ExpiredAccountController', ExpiredAccountController);
 
 function ExpiredAccountController(
-  close,
   $rootScope,
-  $scope
+  $scope,
+  close,
+  currentOrg
 ) {
   var EAC = this;
   EAC.close = close;
 
   EAC.activeAccount = $rootScope.dataApp.data.activeAccount;
+  EAC.currentOrg = currentOrg;
 
   EAC.actions = {
     close: function () {

--- a/client/directives/modals/settingsModal/forms/billingForm/confirmationForm/confirmationForm.jade
+++ b/client/directives/modals/settingsModal/forms/billingForm/confirmationForm/confirmationForm.jade
@@ -16,10 +16,11 @@
 
 footer.modal-footer.clearfix
   button.btn.btn-md.btn-block.green(
-    ng-if = "currentOrg.poppa.isInActivePeriod()"
+    ng-if = "EAC.currentOrg.poppa.isInActivePeriod()"
+    ng-click = "EAC.close()"
   ) Go to your Environment
   button.btn.btn-md.btn-block.white(
-    ng-click = "goToPanel('billingForm', 'back');"
-    ng-if = "currentOrg.poppa.isInTrial()"
+    ng-click = "goToPanel('billingForm', 'back')"
+    ng-if = "EAC.currentOrg.poppa.isInTrial()"
     type = "button"
   ) Billing Overview


### PR DESCRIPTION
When a user submits a payment, the buttons that should appear will again! Something seems to have been moved out of scope, which caused both ng-ifs to be falsy.