### PR TITLE
Quick fix for add services modal closing

### DIFF
--- a/client/directives/instances/instance/branchMenuPopover/templateMenuPopoverView.jade
+++ b/client/directives/instances/instance/branchMenuPopover/templateMenuPopoverView.jade
@@ -2,7 +2,6 @@
   close = "NCMC.close"
   new-container = "popover"
   ng-class = "{'in': active}"
-  ng-if = "!CIS.currentOrg.isPersonalAccount()"
   ng-init = "\
     state.tab = 'repo';\
     state.loading = null;\


### PR DESCRIPTION
This causes the add services popover to close instantly as the scope no longer has access to CIS, so it always returns false and always closes. It is not necessary because the trigger element won't appear if it is a personal account.