### PR TITLE
Now dockerfile will change in UI when branch is changed

### DIFF
--- a/client/directives/components/fancySelectors/branchSelector/branchSelectorDirective.js
+++ b/client/directives/components/fancySelectors/branchSelector/branchSelectorDirective.js
@@ -56,6 +56,9 @@ require('app')
               $scope.loadingPromisesTarget,
               promisify($scope.state.acv, 'update')(newState)
             )
+              .then(function () {
+                $scope.$emit('updatedACV');
+              })
               .catch(errs.handler);
           }
         };

--- a/client/directives/environment/modals/modalSetupServer/setupMirrorServerModalController.js
+++ b/client/directives/environment/modals/modalSetupServer/setupMirrorServerModalController.js
@@ -32,6 +32,10 @@ function SetupMirrorServerModalController(
   SMC.isAddingFirstRepo = ahaGuide.isAddingFirstRepo;
   SMC.showUrlToolbar = SMC.isAddingFirstRepo();
 
+  $scope.$on('updatedACV', function () {
+    SMC.openDockerfile(SMC.state, SMC.openItems);
+  });
+
   var parentController = $controller('ServerModalController as SMC', { $scope: $scope });
   angular.extend(SMC, {
     'changeTab': parentController.changeTab.bind(SMC),

--- a/test/unit/controllers/setupMirrorServerModalController.unit.js
+++ b/test/unit/controllers/setupMirrorServerModalController.unit.js
@@ -599,5 +599,15 @@ describe('setupMirrorServerModalController'.bold.underline.blue, function () {
       sinon.assert.calledOnce(errsMock.handler);
     });
   });
+
+  describe('changing the branch should change dockerfile', function () {
+    beforeEach(initState.bind(null, {}));
+    it('should call openDockerfile if the ACV event is emitted', function () {
+      SMC.openDockerfile = sinon.stub();
+      $scope.$emit('updatedACV');
+      $scope.$digest();
+      sinon.assert.calledOnce(SMC.openDockerfile);
+    });
+  });
 });
 


### PR DESCRIPTION
This PR will change the UI in the dockerfile tab when the branch is changed, reflecting the dockerfile in that branch. This would not change the build itself, which does reflect the dockerfile in a branch even if the UI didn't.

To test - The RunnableDemo org has a node-api repo with multiple branches. Master has a dockerfile with typical stuff, while the test-dockerfile branch just has a sleep command. Change branch, observe changes.