### PR TITLE
Add region to AWS gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -354,6 +354,7 @@ module.exports = function(grunt) {
         accessKeyId: process.env.AWS_ACCESS_KEY,
         secretAccessKey: process.env.AWS_SECRET_KEY,
         bucket: process.env.AWS_BUCKET,
+        region: process.env.AWS_REGION,
         createBucket: true,
         enableWeb: true,
         gzip: true,


### PR DESCRIPTION
We need the ability to change this if needed. Default is `us-standard`.