### PR TITLE
Fix test failures on runnable

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -229,6 +229,9 @@ module.exports = function(grunt) {
       }
     },
     bgShell: {
+      _defaults: {
+        fail: true
+      },
       karma: {
         bg: false,
         cmd: 'karma start ./test/karma.conf.js --single-run'


### PR DESCRIPTION
This will fix the issue where we had check marks in our PRs but our tests were failing in Runnable. The added "fail: true" property will ensure the process exits on fail, which it currently does not, resulting in a non-zero exit code.

I also added test coverage to the test task that will also fail if it does not meet requirements.