### PR TITLE
Hide the instance ui if it's been destroyed!

### DIFF
--- a/client/templates/viewInstance.jade
+++ b/client/templates/viewInstance.jade
@@ -8,7 +8,7 @@
   ng-if = "!isLoading.main"
 )
   .grid-block.justify-center.align-center(
-    ng-if = "!dataInstance.data.instance"
+    ng-if = "!dataInstance.data.instance || dataInstance.data.instance.destroyed"
   )
     img(
       height = "40"
@@ -16,7 +16,7 @@
       width = "40"
     )
   .grid-block.vertical(
-    ng-if = "dataInstance.data.instance"
+    ng-if = "dataInstance.data.instance && !dataInstance.data.instance.destroyed"
   )
     //- show if server build is being swapped out
       - orange when build is updating or has failed


### PR DESCRIPTION
This fixes `cannot read property opts of undefined` error