### PR TITLE
Fix issue with specifying path, not file

### DIFF
--- a/client/directives/validators/dockerfileExistsValidatorDirective.js
+++ b/client/directives/validators/dockerfileExistsValidatorDirective.js
@@ -5,7 +5,8 @@ require('app').directive('dockerfileExistsValidator', dockerfileExistsValidator)
 function dockerfileExistsValidator(
   $q,
   doesDockerfileExist,
-  fetchRepoDockerfile
+  fetchRepoDockerfile,
+  keypather
 ) {
   return {
     require: 'ngModel',
@@ -26,7 +27,7 @@ function dockerfileExistsValidator(
         return fetchRepoDockerfile($scope.fullRepo, $scope.branchName, modelValue)
           .then(doesDockerfileExist)
           .then(function (dockerfile) {
-            if (!dockerfile) {
+            if (!keypather.get(dockerfile, 'content')) {
               return $q.reject('file doesn’t exist');
             }
             $scope.$emit('dockerfileExistsValidator::valid', modelValue, attrs.dockerfileExistsValidator);


### PR DESCRIPTION
The content field is a base64 encoded string of the file's contents. A request for a path ('/') will return an array.