### PR TITLE
add testing events

### DIFF
--- a/client/directives/components/lists/branchTestList/branchTestListView.jade
+++ b/client/directives/components/lists/branchTestList/branchTestListView.jade
@@ -2,6 +2,6 @@ section(
   branch-test-selector
   branch = "BTLC.branch"
   commit = "BTLC.commit"
-  instance-name = "BTLC.instance.attrs.name"
   hide-branch-selector = "!BTLC.appCodeVersion.attrs.additionalRepo"
+  instance-name = "BTLC.instance.attrs.name"
 )

--- a/client/directives/components/lists/branchTestSelector/branchTestSelectorView.jade
+++ b/client/directives/components/lists/branchTestSelector/branchTestSelectorView.jade
@@ -24,8 +24,9 @@ ul.list.margin-top-sm(
     ng-repeat = "commit in commits = (BTSC.branch.commits.models | filter: BTSC.hasTest | orderBy: '-attrs.commit.committer.date')"
   )
     a.grid-block.vertical(
-      ui-sref = "base.instances.instance-test-sha({instanceName: BTSC.instanceName, sha: commit.attrs.sha})"
+      data-event-name = "Selected Test Commit"
       ng-click = "BTSC.selectCommit(commit, $index === 0)"
+      ui-sref = "base.instances.instance-test-sha({instanceName: BTSC.instanceName, sha: commit.attrs.sha})"
     )
       p.p.text-overflow(
         ng-attr-title = "{{commit.attrs.commit.message}}"

--- a/client/directives/components/lists/branchTestSelector/testSelectorHeaderView.jade
+++ b/client/directives/components/lists/branchTestSelector/testSelectorHeaderView.jade
@@ -1,6 +1,7 @@
 .p.weight-strong Test History
 small.small Select a previously run test to view.
 button.grid-block.shrink.margin-top-xxs.btn.btn-xs.orange(
-  ng-disabled = "BTSC.isLatestCommit()"
+  data-event-name = "Cleared Test History"
   ng-click = "BTSC.setToLatestCommit()"
+  ng-disabled = "BTSC.isLatestCommit()"
 ) Clear Selection


### PR DESCRIPTION
Adds events for:
- Clearing test selection.
- Select a test commit from the test popover.