### PR TITLE
SAN-6027 Only show one instance as active

### DIFF
--- a/client/services/composeCardActiveService.js
+++ b/client/services/composeCardActiveService.js
@@ -11,6 +11,7 @@ function composeCardActive(
   return function (composeCluster) {
     return isInstanceActive(composeCluster.master) ||
       getPathShortHash() === composeCluster.master.attrs.shortHash ||
-      isInstanceActive(keypather.get(composeCluster, 'testing[0]'));
+      isInstanceActive(keypather.get(composeCluster, 'testing[0]')) ||
+      getPathShortHash() === keypather.get(composeCluster, 'testing[0].attrs.shortHash');
   };
 }

--- a/client/services/isInstanceActiveService.js
+++ b/client/services/isInstanceActiveService.js
@@ -4,8 +4,7 @@ require('app')
   .factory('isInstanceActive', isInstanceActive);
 
 function isInstanceActive(
-  $state,
-  getPathShortHash
+  $state
 ) {
   return function (instance) {
     if (!instance) {


### PR DESCRIPTION
Fixed nav naming, making sure we only determine if the instance is active vs compose card active.