### PR TITLE
add "add service" cta for compose sidebar

### DIFF
--- a/client/assets/styles/scss/deprecated/service-cta.scss
+++ b/client/assets/styles/scss/deprecated/service-cta.scss
@@ -1,12 +1,14 @@
 //- ************************
 //- deprecated file, delete with $root.featureFlags.demoPersonalOnly
-.service-cta .demo-progress {
-  width: calc(100% + 30px);
-}
+.service-cta {
 
-.popover-demo.service-cta {
-  margin-bottom: 9px;
-  margin-top: 5px;
+  &:not(.deprecated) {
+    margin-top: -4px;
+  }
+
+  &.deprecated {
+    margin-top: 4px;
+  }
 }
 //- end deprecated file
 //- ************************

--- a/client/assets/styles/scss/index.scss
+++ b/client/assets/styles/scss/index.scss
@@ -213,6 +213,7 @@
 @import "deprecated/connections";
 @import "deprecated/deleted-commit";
 @import "deprecated/demo-org-select";
+@import "deprecated/service-cta";
 @import "deprecated/instance-sidebar";
 @import "deprecated/popover-container-menu";
 

--- a/client/templates/instances/servicesSectionView.jade
+++ b/client/templates/instances/servicesSectionView.jade
@@ -12,6 +12,11 @@ h2.grid-block.align-center.justify-justified.nav-section-header Services
         xlink:href = "#icons-arrow-down"
       )
 
+.grid-block.vertical.padding-sm.popover.bottom.in.popover-demo.service-cta.margin-bottom-xs(
+  add-service-cta
+  ng-if = "CIS.shouldShowServicesCTA() && !$root.featureFlags.demoPersonalOnly"
+)
+
 .grid-block.align-center.padding-sm.popover.top.in.popover-demo(
   ng-if = "CIS.showInstanceRunningPopover() && !$root.featureFlags.demoPersonalOnly"
   ng-include = "'popoverDemoUrlHiddenView'"

--- a/client/templates/instances/viewInstancesList.jade
+++ b/client/templates/instances/viewInstancesList.jade
@@ -64,7 +64,7 @@
         ng-include = "'servicesHeadingView'"
       )
 
-      .grid-block.vertical.padding-sm.popover.bottom.in.popover-demo.service-cta.margin-bottom-xs(
+      .grid-block.vertical.padding-sm.popover.bottom.in.popover-demo.service-cta.margin-bottom-xs.deprecated(
         add-service-cta
         ng-if = "CIS.shouldShowServicesCTA() && !$root.featureFlags.demoPersonalOnly"
       )


### PR DESCRIPTION
Fixes missing "add service" CTA (for orgs in the demo flow) when Compose feature flags are on