### PR TITLE
Fix alignment for File Explorer toggle in Firefox

### DIFF
--- a/client/templates/viewInstance.jade
+++ b/client/templates/viewInstance.jade
@@ -45,7 +45,7 @@
     )
 
     .grid-block.instance-body
-      button.grid-block.shrink.btn.btn-sm(
+      .grid-block.shrink.btn.btn-sm(
         data-event-name = "Toggled File Explorer"
         ng-class = "{'active': !$root.featureFlags.hideExplorer}"
         ng-click = "$root.featureFlags.hideExplorer = !$root.featureFlags.hideExplorer"


### PR DESCRIPTION
Fixes this in Firefox:
![image](https://cloud.githubusercontent.com/assets/7440805/24779835/a535f03a-1ae7-11e7-8e26-aa8884fba02b.png)
