### PR TITLE
minify css on prod

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -618,7 +618,7 @@ module.exports = function(grunt) {
   ]);
   grunt.registerTask('deploy:prod', [
     'copy',
-    'sass:dev',
+    'sass:compile',
     'autoprefixer',
     'jade2js',
     'autoBundleDependencies',


### PR DESCRIPTION
For some reason, we don't minify CSS when we deploy to prod, but we _probably_ should.